### PR TITLE
ignore minishell binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# minishell custom
+minishell


### PR DESCRIPTION
fixed #95 
現状だと`minishell`が生成されているとgitの追跡対象になってしまうので、
`.gitignore`にminishellを追加して対象外にしました。