### PR TITLE
signalの対応を追加しました。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/04/03 12:55:20 by ttsubo            #+#    #+#              #
-#    Updated: 2025/04/03 13:15:40 by ttsubo           ###   ########.fr        #
+#    Updated: 2025/04/05 13:45:55 by ttsubo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -22,7 +22,7 @@ W_FLG = -Wall -Wextra -Werror
 I_FLG = -I$(INC_DIR)
 L_FLG = -lreadline
 
-SRC = main.c
+SRC = main.c minish_signal.c
 
 SRCS = $(addprefix $(SRC_DIR), $(SRC))
 OBJS = $(addprefix $(OBJ_DIR), $(SRC:.c=.o))

--- a/inc/minish_signal.h
+++ b/inc/minish_signal.h
@@ -1,22 +1,22 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   main.h                                             :+:      :+:    :+:   */
+/*   minish_signal.h                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/04/03 12:50:38 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/05 13:38:02 by ttsubo           ###   ########.fr       */
+/*   Created: 2025/04/05 13:35:17 by ttsubo            #+#    #+#             */
+/*   Updated: 2025/04/05 14:13:59 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef MAIN_H
-# define MAIN_H
-
-# include "minish_signal.h"
+#ifndef MINISH_SIGNAL_H
+# define MINISH_SIGNAL_H
 
 # include <readline/readline.h>
+# include <signal.h>
 # include <stdio.h>
-# include <stdlib.h>
+
+void	minish_signal(void);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/03 12:50:11 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/03 12:54:30 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/05 13:48:09 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@ int	main(void)
 {
 	char	*line;
 
+	minish_signal();
 	while (1)
 	{
 		line = readline("minish>");

--- a/src/minish_signal.c
+++ b/src/minish_signal.c
@@ -1,0 +1,63 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   minish_signal.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/05 13:35:06 by ttsubo            #+#    #+#             */
+/*   Updated: 2025/04/05 14:46:39 by ttsubo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minish_signal.h"
+
+/**
+ * @brief ctrl+cを押されたときのハンドラ関数
+ * 
+ * @param signum 
+ */
+static void	ctrl_c(int signum)
+{
+	(void)signum;
+	printf("\n");
+	rl_on_new_line();
+	rl_replace_line("", 0);
+	rl_redisplay();
+}
+
+/**
+ * @brief sigaction構造体の値を設定します。
+ * 
+ * @param sa		: sigaction構造体
+ * @param handler	: ハンドラ関数
+ * @note sigaction構造体のうち、次の値を設定しています。
+ * @note - sa_handler	:ハンドラ関数。引数fを設定します。NULLの場合はSIG_IGN。
+ * @note - sa_mask		:ハンドラ実行中にブロックするマスク。ブロックはしない。
+ * @note - sa_flags		:ハンドラの挙動を制御するフラグ。特に設定しない。
+ */
+static void	_set_sigaction(struct sigaction *sa, void (*handler)(int))
+{
+	if (!handler)
+		sa->sa_handler = SIG_IGN;
+	else
+		sa->sa_handler = handler;
+	sigemptyset(&(sa->sa_mask));
+	sa->sa_flags = 0;
+}
+
+/**
+ * @brief SIGINT(ctrl+c), SIGQUIT(ctrl+\)を設定します。
+ * 
+ * @note ctrl+dはEOFのため、別途管理しています。
+ */
+void	minish_signal(void)
+{
+	struct sigaction	sa_int;
+	struct sigaction	sa_quit;
+
+	_set_sigaction(&sa_int, ctrl_c);
+	_set_sigaction(&sa_quit, NULL);
+	sigaction(SIGINT, &sa_int, NULL);
+	sigaction(SIGQUIT, &sa_quit, NULL);
+}


### PR DESCRIPTION
fix #18, fix #19, fix #20, fix #21

signal関連の対応を`signal[.c|.h]`というファイルに実装しました。
次のことをできるようにしています。
- `ctrl+c`: 新しい行に切り替えます。
- `ctrl+\`: 何もしないようにしています。

なお、`ctrl+d`についてはmain側でEOFを感知した場合に抜けることで対応しています。
（後々なにか対応が必要になるかも？）