### PR TITLE
#120 ビルトインのテスト用Makefileを一つに統合

### DIFF
--- a/test.mk
+++ b/test.mk
@@ -6,7 +6,7 @@
 #    By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/04/14 11:48:18 by ttsubo            #+#    #+#              #
-#    Updated: 2025/04/14 21:01:49 by ttsubo           ###   ########.fr        #
+#    Updated: 2025/04/14 21:15:30 by ttsubo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -17,13 +17,14 @@
 I_FLG = -Iinc -Ilib/libft 
 L_FLG = -Llib/libft -lft -lreadline
 
-# 
+# testを追加する場合はSRCにファイル名を追加してください。 
 SRC = cd.c exit.c
+OUT = $(addprefix test_, $(SRC:.c=.out))
 
-all:
-	cc tests/builtin/test_cd.c src/builtin/cd.c -Llib/libft -lft -Iinc -Ilib/libft -o test_cd.out
-	cc tests/builtin/test_exit.c src/builtin/exit.c -Ilib/libft -Llib/libft -lft -Iinc -lreadline -o test_exit
+all: $(OUT)
+
+test_%.out: tests/builtin/test_%.c src/builtin/%.c
+	cc $^ $(L_FLG) $(I_FLG) -o $@
 
 clean:
-	rm -f test_cd.out
-	rm -f test_exit
+	rm -f test_*.out

--- a/test.mk
+++ b/test.mk
@@ -1,17 +1,29 @@
 # **************************************************************************** #
 #                                                                              #
 #                                                         :::      ::::::::    #
-#    Maketest.mk                                        :+:      :+:    :+:    #
+#    test.mk                                            :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
 #    By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/04/14 11:48:18 by ttsubo            #+#    #+#              #
-#    Updated: 2025/04/14 11:49:08 by ttsubo           ###   ########.fr        #
+#    Updated: 2025/04/14 21:01:49 by ttsubo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
+# usage
+# make -f test.mk
+# make -f test.mk clean
+
+I_FLG = -Iinc -Ilib/libft 
+L_FLG = -Llib/libft -lft -lreadline
+
+# 
+SRC = cd.c exit.c
+
 all:
-	cc tests/builtin/test_cd.c src/builtin/cd.c -Llib/libft -lft -Iinc -o test_cd.out
+	cc tests/builtin/test_cd.c src/builtin/cd.c -Llib/libft -lft -Iinc -Ilib/libft -o test_cd.out
+	cc tests/builtin/test_exit.c src/builtin/exit.c -Ilib/libft -Llib/libft -lft -Iinc -lreadline -o test_exit
 
 clean:
 	rm -f test_cd.out
+	rm -f test_exit


### PR DESCRIPTION
fixed #120 
ビルトインのテスト用Makefileを`test.mk`という名前のファイルにひとまとめにしました。

以降はtest_<cmd>.cがbuiltin/以下に存在することを前提に
SRCに対象のコマンドのソースコードを追加することで対応できます。

