### PR TITLE
リダイレクトのタイプをenumで追加

### DIFF
--- a/inc/cmd.h
+++ b/inc/cmd.h
@@ -6,15 +6,25 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/13 13:47:36 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/13 13:51:21 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/14 21:30:15 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef CMD_H
 # define CMD_H
 
+typedef enum e_redir_type
+{
+	REDIR_NONE,
+	REDIR_OUT,
+	REDIR_APPEND,
+	REDIR_IN,
+	REDIR_HEREDOC
+}					t_redir_type;
+
 typedef struct s_cmd
 {
+	t_redir_type	type;
 	int				argc;
 	char			**argv;
 	int				capa;


### PR DESCRIPTION
fixed #111 
cmdの構造体にリダイレクトの種類を判定するためのenum変数を追加しました。
字句解析での判定で利用する予定です。