### PR TITLE
add built-in env

### DIFF
--- a/src/builtin/env.c
+++ b/src/builtin/env.c
@@ -1,0 +1,37 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env.c                                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/14 16:19:11 by dayano            #+#    #+#             */
+/*   Updated: 2025/04/15 10:48:56 by dayano           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "main.h"
+
+// env with no options or arguments
+
+static void	_error_mes(char *name)
+{
+	ft_putstr_fd(name, STDERR_FILENO);
+	ft_putstr_fd(": too many arguments\n", STDERR_FILENO);
+}
+
+int	builtin_env(int argc, char *argv[], char *envp[])
+{
+	int	i;
+
+	if (argc != 1)
+		return (_error_mes(argv[0]), EXIT_FAILURE);
+	i = 0;
+	while (envp[i] != NULL)
+	{
+		if (printf("%s\n", envp[i]) < 0)
+			return (perror("printf"), EXIT_FAILURE);
+		i++;
+	}
+	return (EXIT_SUCCESS);
+}

--- a/test.mk
+++ b/test.mk
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    test.mk                                            :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+         #
+#    By: dayano <dayano@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/04/14 11:48:18 by ttsubo            #+#    #+#              #
-#    Updated: 2025/04/14 21:15:30 by ttsubo           ###   ########.fr        #
+#    Updated: 2025/04/15 11:14:35 by dayano           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -14,11 +14,11 @@
 # make -f test.mk
 # make -f test.mk clean
 
-I_FLG = -Iinc -Ilib/libft 
+I_FLG = -Iinc -Ilib/libft
 L_FLG = -Llib/libft -lft -lreadline
 
-# testを追加する場合はSRCにファイル名を追加してください。 
-SRC = cd.c exit.c
+# testを追加する場合はSRCにファイル名を追加してください。
+SRC = cd.c exit.c env.c
 OUT = $(addprefix test_, $(SRC:.c=.out))
 
 all: $(OUT)

--- a/tests/builtin/test_env.c
+++ b/tests/builtin/test_env.c
@@ -1,23 +1,19 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   builtin.h                                          :+:      :+:    :+:   */
+/*   test_env.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/04/13 17:19:01 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/15 10:25:36 by dayano           ###   ########.fr       */
+/*   Created: 2025/04/15 10:24:45 by dayano            #+#    #+#             */
+/*   Updated: 2025/04/15 10:25:03 by dayano           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef BUILTIN_H
-# define BUILTIN_H
+#include "main.h"
 
-# define PATH_MAX 4096
-
-int	builtin_pwd(int argc, char *argv[]);
-int	builtin_exit(int argc, char *argv[]);
-int	builtin_cd(int argc, char *argv[]);
-int	builtin_env(int argc, char *argv[], char *envp[]);
-
-#endif
+int	main(int argc, char **argv, char **envp)
+{
+	builtin_env(argc, argv, envp);
+	return (0);
+}


### PR DESCRIPTION
fix #28 

課題
プロトタイプを```int	builtin_env(int argc, char *argv[], char *envp[])```としており、main関数からenvpを受け渡す必要があります。（この実装はまだしていない。issueに追加します。）

対処
envpさえ渡せれば、envのオプション・引数なしとして十分に動作します。そのため、
main関数からbuilt-in系のコマンドへの繋がりがはっきりし、この実装が問題になった場合には再実装する方針を考えています。

