### PR TITLE
fix char **envp to t_env

### DIFF
--- a/inc/builtin.h
+++ b/inc/builtin.h
@@ -6,7 +6,7 @@
 /*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/13 17:19:01 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/15 11:40:57 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/17 15:21:13 by dayano           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,6 @@ int	builtin_echo(int argc, char *argv[]);
 int	builtin_pwd(int argc, char *argv[]);
 int	builtin_exit(int argc, char *argv[]);
 int	builtin_cd(int argc, char *argv[]);
-int	builtin_env(int argc, char *argv[], char *envp[]);
+int	builtin_env(int argc, char **argv, t_minish *minish)
 
 #endif

--- a/inc/builtin.h
+++ b/inc/builtin.h
@@ -6,7 +6,7 @@
 /*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/13 17:19:01 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/17 15:21:13 by dayano           ###   ########.fr       */
+/*   Updated: 2025/04/17 15:53:46 by dayano           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,6 @@ int	builtin_echo(int argc, char *argv[]);
 int	builtin_pwd(int argc, char *argv[]);
 int	builtin_exit(int argc, char *argv[]);
 int	builtin_cd(int argc, char *argv[]);
-int	builtin_env(int argc, char **argv, t_minish *minish)
+int	builtin_env(int argc, char **argv, t_minish *minish);
 
 #endif

--- a/inc/builtin.h
+++ b/inc/builtin.h
@@ -6,7 +6,7 @@
 /*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/13 17:19:01 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/17 15:53:46 by dayano           ###   ########.fr       */
+/*   Updated: 2025/04/17 15:57:28 by dayano           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,8 @@
 # define BUILTIN_H
 
 # define PATH_MAX 4096
+
+# include "struct.h"
 
 int	builtin_echo(int argc, char *argv[]);
 int	builtin_pwd(int argc, char *argv[]);

--- a/inc/struct.h
+++ b/inc/struct.h
@@ -1,27 +1,27 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   main.h                                             :+:      :+:    :+:   */
+/*   struct.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/04/03 12:50:38 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/17 15:20:58 by dayano           ###   ########.fr       */
+/*   Created: 2025/04/15 17:10:22 by dayano            #+#    #+#             */
+/*   Updated: 2025/04/17 15:07:53 by dayano           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef MAIN_H
-# define MAIN_H
+#ifndef STRUCT_H
+# define STRUCT_H
 
-# include "builtin.h"
-# include "cmd.h"
-# include "libft.h"
-# include "minish_signal.h"
-# include "struct.h"
-# include <readline/history.h>
-# include <readline/readline.h>
-# include <stdio.h>
-# include <stdlib.h>
-# include <unistd.h>
+typedef struct s_env
+{
+	char			*value;
+	struct s_env	*next;
+}					t_env;
+
+typedef struct s_minish
+{
+	t_env			*env;
+}					t_minish;
 
 #endif

--- a/src/builtin/env.c
+++ b/src/builtin/env.c
@@ -6,13 +6,11 @@
 /*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 16:19:11 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/15 10:48:56 by dayano           ###   ########.fr       */
+/*   Updated: 2025/04/17 15:20:41 by dayano           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "main.h"
-
-// env with no options or arguments
 
 static void	_error_mes(char *name)
 {
@@ -20,18 +18,20 @@ static void	_error_mes(char *name)
 	ft_putstr_fd(": too many arguments\n", STDERR_FILENO);
 }
 
-int	builtin_env(int argc, char *argv[], char *envp[])
+int	builtin_env(int argc, char **argv, t_minish *minish)
 {
-	int	i;
+	t_env	*next;
+	t_env	*current;
 
 	if (argc != 1)
 		return (_error_mes(argv[0]), EXIT_FAILURE);
-	i = 0;
-	while (envp[i] != NULL)
+	current = minish->env;
+	while (current)
 	{
-		if (printf("%s\n", envp[i]) < 0)
-			return (perror("printf"), EXIT_FAILURE);
-		i++;
+		next = current->next;
+		if (printf("%s\n", current->value) < 0)
+			handle_error_and_exit("printf", minish);
+		current = next;
 	}
 	return (EXIT_SUCCESS);
 }

--- a/test.mk
+++ b/test.mk
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    test.mk                                            :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+         #
+#    By: dayano <dayano@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/04/14 11:48:18 by ttsubo            #+#    #+#              #
-#    Updated: 2025/04/18 14:57:31 by ttsubo           ###   ########.fr        #
+#    Updated: 2025/04/18 16:05:23 by dayano           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -21,7 +21,7 @@ MAKEFLAGS += --no-print-directory
 I_FLG = -Iinc -Ilib/libft
 L_FLG = -Llib/libft -lft -lreadline
 
-# testを追加する場合はSRCにファイル名を追加してください。 
+# testを追加する場合はSRCにファイル名を追加してください。
 SRC = cd.c exit.c echo.c env.c unset.c tokenizer.c
 
 OUT = $(addprefix test_, $(SRC:.c=.out))
@@ -34,7 +34,10 @@ test_%.out: tests/builtin/test_%.c src/builtin/%.c
 test_%.out: tests/tokenizer/test_%.c
 	$(CC) $^ src/tokenizer/*.c $(L_FLG) $(I_FLG) -o $@
 
-test_unset.out: tests/builtin/test_unset.c 
+test_unset.out: tests/builtin/test_unset.c
+	$(CC) $< src/initialize.c src/builtin/*.c $(L_FLG) $(I_FLG) -o $@
+
+test_env.out: tests/builtin/test_env.c
 	$(CC) $< src/initialize.c src/builtin/*.c $(L_FLG) $(I_FLG) -o $@
 
 clean:

--- a/tests/builtin/test_env.c
+++ b/tests/builtin/test_env.c
@@ -6,14 +6,57 @@
 /*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 10:24:45 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/15 10:25:03 by dayano           ###   ########.fr       */
+/*   Updated: 2025/04/18 16:11:30 by dayano           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "main.h"
 
+static size_t	_count_words(char **cmds)
+{
+	size_t	i;
+
+	i = 0;
+	while (cmds[i])
+		i++;
+	return (i);
+}
+
+static void	cmds_free(char **cmds)
+{
+	size_t	i;
+	size_t	length;
+
+	i = 0;
+	length = _count_words(cmds);
+	while (i < length)
+		free(cmds[i++]);
+	free(cmds);
+}
+
 int	main(int argc, char **argv, char **envp)
 {
-	builtin_env(argc, argv, envp);
-	return (0);
+	char		*line;
+	char		**cmds;
+	t_minish	*minish;
+
+	(void)argc;
+	(void)argv;
+	minish = initialize(envp);
+	while (1)
+	{
+		line = readline("minish>");
+		if (!line)
+			break ;
+		if (line[0] == '\0')
+			continue ;
+		cmds = ft_split(line, ' ');
+		if (!ft_strcmp(cmds[0], "env"))
+			builtin_env(_count_words(cmds), cmds, minish);
+		cmds_free(cmds);
+		free(line);
+	}
+	cleanup_minish(minish);
+	free(line);
+	return (EXIT_SUCCESS);
 }


### PR DESCRIPTION
t_envにminishell独自のenvpの構造体もたせた。そのため、built-in envも修正する必要が合った。