### PR TITLE
env構造体にkeyを追加、それを利用していた関数の修正

### DIFF
--- a/inc/env_utils.h
+++ b/inc/env_utils.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env_utils.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/17 10:25:47 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/17 10:29:25 by dayano           ###   ########.fr       */
+/*   Updated: 2025/04/20 19:01:56 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,6 @@
 
 # include "struct.h"
 
-char	*get_env_name(const char *env_entry);
 void	free_env_content(char *value);
 void	remove_env_node(t_env **env_lst, t_env *target);
 

--- a/inc/struct.h
+++ b/inc/struct.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   struct.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 17:10:22 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/17 16:06:27 by dayano           ###   ########.fr       */
+/*   Updated: 2025/04/20 18:05:54 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 
 typedef struct s_env
 {
+	char			*key;
 	char			*value;
 	struct s_env	*next;
 }					t_env;

--- a/src/builtin/env.c
+++ b/src/builtin/env.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 16:19:11 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/17 15:20:41 by dayano           ###   ########.fr       */
+/*   Updated: 2025/04/20 18:45:04 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ int	builtin_env(int argc, char **argv, t_minish *minish)
 	while (current)
 	{
 		next = current->next;
-		if (printf("%s\n", current->value) < 0)
+		if (printf("%s=%s\n", current->key, current->value) < 0)
 			handle_error_and_exit("printf", minish);
 		current = next;
 	}

--- a/src/builtin/env_utils.c
+++ b/src/builtin/env_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env_utils.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/17 10:26:59 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/17 14:08:36 by dayano           ###   ########.fr       */
+/*   Updated: 2025/04/20 18:55:27 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,6 +35,7 @@ void	del_one_env_value(t_env *lst, void (*del)(char *))
 {
 	if (!lst || !del)
 		return ;
+	del(lst->key);
 	del(lst->value);
 	free(lst);
 }

--- a/src/builtin/env_utils.c
+++ b/src/builtin/env_utils.c
@@ -6,25 +6,11 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/17 10:26:59 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/20 18:55:27 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/20 19:02:10 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "main.h"
-
-char	*get_env_name(const char *env_entry)
-{
-	char	*eq_pos;
-	char	*env_name;
-	int		name_len;
-
-	eq_pos = ft_strchr(env_entry, '=');
-	if (!eq_pos)
-		return (NULL);
-	name_len = eq_pos - env_entry;
-	env_name = ft_substr(env_entry, 0, name_len);
-	return (env_name);
-}
 
 void	free_env_content(char *value)
 {

--- a/src/builtin/env_utils_2.c
+++ b/src/builtin/env_utils_2.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env_utils_2.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/17 11:17:22 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/17 11:39:05 by dayano           ###   ########.fr       */
+/*   Updated: 2025/04/20 19:36:26 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,8 @@ void	free_env_list(t_env *head)
 	while (head)
 	{
 		next = head->next;
-		free(head->next);
+		free(head->key);
+		free(head->value);
 		free(head);
 		head = next;
 	}

--- a/src/builtin/unset.c
+++ b/src/builtin/unset.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   unset.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 11:35:46 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/17 10:29:26 by dayano           ###   ########.fr       */
+/*   Updated: 2025/04/20 18:57:40 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,11 +24,9 @@ static void	_error_mes(char *name, char *mes)
 
 static int	is_value(char **value, int value_count, t_env *env)
 {
-	char	*env_name;
 	int		i;
 
-	env_name = get_env_name(env->value);
-	if (!env_name)
+	if (!env->key)
 	{
 		ft_putstr_fd("Error: malformed environment entry: ", STDERR_FILENO);
 		ft_putendl_fd(env->value, STDERR_FILENO);
@@ -37,14 +35,10 @@ static int	is_value(char **value, int value_count, t_env *env)
 	i = 0;
 	while (i < value_count)
 	{
-		if (ft_strcmp(value[i], env_name) == 0)
-		{
-			free(env_name);
+		if (ft_strcmp(value[i], env->key) == 0)
 			return (EXIT_SUCCESS);
-		}
 		i++;
 	}
-	free(env_name);
 	return (EXIT_FAILURE);
 }
 

--- a/src/initialize.c
+++ b/src/initialize.c
@@ -3,14 +3,29 @@
 /*                                                        :::      ::::::::   */
 /*   initialize.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 15:42:46 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/17 12:01:48 by dayano           ###   ########.fr       */
+/*   Updated: 2025/04/20 18:39:53 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "main.h"
+
+static void	_split_key_value(char *env_val, char **key_out, char **val_out)
+{
+	size_t	env_len;
+	size_t	eq_pos;
+
+	env_len = ft_strlen(env_val);
+	eq_pos = ft_strlen_until(env_val, '=');
+	*key_out = NULL;
+	*val_out = NULL;
+	if (eq_pos == ft_strlen(env_val))
+		return ;
+	*key_out = ft_substr(env_val, 0, eq_pos);
+	*val_out = ft_substr(env_val, eq_pos + 1, env_len - eq_pos - 1);
+}
 
 static t_env	*create_envp_list(char **envp)
 {
@@ -27,8 +42,8 @@ static t_env	*create_envp_list(char **envp)
 		node = ft_calloc(1, sizeof(t_env));
 		if (!node)
 			return (NULL);
-		node->value = ft_strdup(envp[i]);
-		if (!node->value)
+		_split_key_value(envp[i], &(node->key), &(node->value));
+		if (!node->key || !node->value)
 			return (free(node), NULL);
 		node->next = NULL;
 		if (!head)

--- a/tests/builtin/test_unset.c
+++ b/tests/builtin/test_unset.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 11:53:38 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/18 22:06:40 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/20 18:59:35 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,7 +58,7 @@ static void	cmds_free(char **cmds)
 static void	_exec_cmd(char *line, char **cmds, t_minish *minish)
 {
 	if (!ft_strcmp(cmds[0], "env"))
-		_builtin_env(_count_words(cmds), cmds, minish);
+		builtin_env(_count_words(cmds), cmds, minish);
 	if (!ft_strcmp(cmds[0], "unset"))
 	{
 		if (builtin_unset(_count_words(cmds), cmds, minish))


### PR DESCRIPTION
fixed #141 

- t_env構造体にkeyを格納する変数を追加しました。
- それに伴い、env,unsetの挙動を修正しております。
- 変更に伴って未使用になった関数は削除しました。(env_utils.cのget_env_name())

あと、ダブルフリーを起きている箇所があったので修正してあります。
詳細はコメントにて