### PR TITLE
日本語コメントの英語化

### DIFF
--- a/lib/libft/ft_memmove.c
+++ b/lib/libft/ft_memmove.c
@@ -6,24 +6,24 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/28 13:44:03 by ttsubo            #+#    #+#             */
-/*   Updated: 2024/12/23 19:56:10 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:10:56 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
 /**
- * @brief src領域をdst領域にオーバーラップを考慮したコピーを行います。
+ * @brief Copy the src area to the dst area considering overlap.
  * 
- * @param [out]	dst	: コピー先のメモリ領域
- * @param [in]	src	: コピー元のメモリ領域
- * @param [in]	len	: コピーする領域の長さ
- * @return void* 	: dstを返します
+ * @param [out]	dst	:  
+ * @param [in]	src	: 
+ * @param [in]	len	: 
+ * @return void* 	: return dst
  * @note : 
- * 	dstとsrcのメモリアドレス番地の位置で挙動が変わります。
- * 	dst <  src なら前方からコピー
- *  dst == src ならdをそのまま返す（内容が同じのため）
- *  それ以外は後方コピーを行います
+ * 	The behavior of this function changes with the position of dst and src.
+ *  If dst < src, copy from the front.	
+ *  If dst == src, returns dst as is.
+ *  Otherwise, copy from behind.
  */
 void	*ft_memmove(void *dst, const void *src, size_t len)
 {

--- a/lib/libft/ft_memset.c
+++ b/lib/libft/ft_memset.c
@@ -6,23 +6,23 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/28 11:54:35 by ttsubo            #+#    #+#             */
-/*   Updated: 2024/12/23 19:38:03 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:14:49 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
 /**
- * @brief メモリ領域bを文字cで穴埋めします
+ * @brief Fill memory area b with letter c. 
  *
- * @param [out]	b	: メモリ領域
- * @param [in]	c	: 穴埋めする文字
- * @param [in]	len	: 穴埋めする長さ
- * @retval void*	: 穴埋めしたメモリ領域
- * @retval NULL		: bがNULLの場合
+ * @param [out]	b	: memory area
+ * @param [in]	c	: fill letter
+ * @param [in]	len	: length
+ * @retval void*	: return b;
+ * @retval NULL		: If b is NULL.
  * @note : 
- * 内部でuchar型にキャストするので、
- * 0-255の範囲外の数字は上位ビットが無視された値で使われます。
+ * This function internally casts int c to uchar.
+ * Therefore, upper bits outside the range 0-255 are ignored in its operation.
  */
 void	*ft_memset(void *b, int c, size_t len)
 {

--- a/lib/libft/ft_printf/srcs/ft_printf.c
+++ b/lib/libft/ft_printf/srcs/ft_printf.c
@@ -6,19 +6,18 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/11 14:24:10 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/01/24 10:58:19 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:35:04 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "ft_printf.h"
 
 /**
- * @brief strが%の場合それに応じたフォーマットを出力します
- *
- * @param str	: %[csdiu%]
- * @param args	: formatに関する引数
- * @return int  : 出力した文字列の長さ
- * @note	pre: %からはじまること
+ * @brief If str is %, output format accordingly
+ * 
+ * @param str 
+ * @param args 
+ * @return int 
  */
 static int	_format(const char **str, va_list *args)
 {
@@ -50,11 +49,12 @@ static int	_format(const char **str, va_list *args)
 }
 
 /**
- * @brief 渡された引数をフォーマットに従って変換し標準出力に出力します
- *
- * @param [in] str 	: 出力する文字列(フォーマットを含む場合もある)
- * @param [in] ... 	: フォーマットに与える変数
- * @return int 		: 出力した文字列の長さ
+ * @brief Outputs str to standard output.
+ * If arguments are present, they are converted to match the format.
+ * 
+ * @param str 
+ * @param ... 
+ * @return int 
  */
 int	ft_printf(const char *str, ...)
 {

--- a/lib/libft/ft_printf/srcs/ft_printf_utils1.c
+++ b/lib/libft/ft_printf/srcs/ft_printf_utils1.c
@@ -6,18 +6,18 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/05 15:09:58 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/01/24 10:58:19 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:28:10 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "ft_printf_utils.h"
 
 /**
- * @brief fdに文字cを出力します
+ * @brief Outputs the letter c to fd.
  *
- * @param c			: 文字
- * @param fd 		: ファイルディスクリプタ
- * @return size_t	: 文字の長さ(おおよそ1)
+ * @param c			: char
+ * @param fd 		: file descriptor
+ * @return size_t	: char length.(approximately 1)
  */
 size_t	ptf_putchar_fd(char c, int fd)
 {
@@ -25,11 +25,11 @@ size_t	ptf_putchar_fd(char c, int fd)
 }
 
 /**
- * @brief 文字列sをfdに出力します
+ * @brief Outputs the string s to fd.
  *
- * @param s 		: 文字列
- * @param fd 		: ファイルディスクリプタ
- * @return size_t	: 文字列の長さ
+ * @param s 		: string
+ * @param fd 		: file descriptor
+ * @return size_t	: string length
  */
 size_t	ptf_putstr_fd(char *s, int fd)
 {
@@ -44,11 +44,11 @@ size_t	ptf_putstr_fd(char *s, int fd)
 }
 
 /**
- * @brief 符号ありの数字numをfdに出力します
+ * @brief Outputs the signed n num to fd.
  *
- * @param num 		: 符号あり整数
- * @param fd 		: ファイルディスクリプタ
- * @return size_t	: 符号なし数値の長さ
+ * @param num 		: int
+ * @param fd 		: file descriptor
+ * @return size_t	: n length
  */
 size_t	ptf_putnum_fd(int n, int fd)
 {
@@ -73,11 +73,11 @@ size_t	ptf_putnum_fd(int n, int fd)
 }
 
 /**
- * @brief 符号なしの数字unumをfdに出力します
+ * @brief Output unsigned number n to fd.
  *
- * @param unum 		: 符号なし数値
- * @param fd 		: ファイルディスクリプタ
- * @return size_t	: 符号なし数値の長さ
+ * @param n 		: ungigned number
+ * @param fd 		: file descriptor
+ * @return size_t	: n length
  */
 size_t	ptf_putunum_fd(unsigned int n, int fd)
 {
@@ -94,13 +94,13 @@ size_t	ptf_putunum_fd(unsigned int n, int fd)
 }
 
 /**
- * @brief 符号なし整数を１６進数形式の文字列で出力します
+ * @brief Output unsigned integer as string in hexadecimal format.
  *
- * @param num		: 変換する符号なし整数
- * @param fd 		: ファイルディスクリプタ
- * @param is_upper	: 大文字表記にするかのフラグ(1だと有効)
- * @return char*	: 変換後の文字列の先頭ポインタ
- * @note			: pre: 負の数は呼び出し元で変換すること
+ * @param num		: Unsigned integer to convert
+ * @param fd 		: file descriptor
+ * @param is_upper	: Flag for capitalization (1 means valid)
+ * @return char*	: First pointer of converted string
+ * @note			: pre: Negative numbers must be converted at the caller
  */
 size_t	ptf_puthex_fd(unsigned int n, int fd, int is_upper)
 {

--- a/lib/libft/ft_printf/srcs/ft_printf_utils2.c
+++ b/lib/libft/ft_printf/srcs/ft_printf_utils2.c
@@ -6,18 +6,18 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/05 15:09:58 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/01/24 10:58:19 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:31:43 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "ft_printf_utils.h"
 
 /**
- * @brief ptf_putptr_fdのアドレス出力用の再帰関数
- *
- * @param hex 		: 16進数のアドレス
- * @param fd 		: ファイルディスクリプタ
- * @return size_t	: 出力した文字の長さ
+ * @brief Recursive function for ptf_putptr_fd address output
+ * 
+ * @param hex 
+ * @param fd 
+ * @return size_t 
  */
 static size_t	_ptf_putptr_fd_rec(uintptr_t hex, int fd)
 {
@@ -34,11 +34,11 @@ static size_t	_ptf_putptr_fd_rec(uintptr_t hex, int fd)
 }
 
 /**
- * @brief ポインタを１６進数形式で出力します
- *
- * @param ptr		: アドレスを出力したいポインタ
- * @param fd		: ファイルディスクリプタ
- * @return size_t	: 出力した文字列の長さ
+ * @brief Output pointer in hexadecimal format
+ * 
+ * @param ptr 
+ * @param fd 
+ * @return size_t 
  */
 size_t	ptf_putptr_fd(void *ptr, int fd)
 {
@@ -52,12 +52,12 @@ size_t	ptf_putptr_fd(void *ptr, int fd)
 }
 
 /**
- * @brief メモリ領域bをcで長さlenまで埋めます
+ * @brief Fill memory area b with letter c. 
  * 
- * @param b 		: メモリ領域
- * @param c 		: 埋める形式 (0-255までの数値)
- * @param len 		: 埋める長さ
- * @return void*	: 適用後のメモリ領域の先頭アドレス
+ * @param b 
+ * @param c 
+ * @param len 
+ * @return void* 
  */
 void	*ftp_memset(void *b, int c, size_t len)
 {

--- a/lib/libft/ft_strlen_until.c
+++ b/lib/libft/ft_strlen_until.c
@@ -6,19 +6,19 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/15 15:38:39 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/02/15 15:42:27 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:16:08 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
 /**
- * @brief 文字stopまでの文字列sの長さを返します。
+ * @brief Returns the length of string s up to character stop. 
  *
  * @param s
  * @param stop
  * @return size_t
- * @note stopが見つからない場合、文字列sの長さが返されます。
+ * @note If stop not found, return s length.
  */
 size_t	ft_strlen_until(const char *s, char stop)
 {

--- a/lib/libft/ft_strnlen.c
+++ b/lib/libft/ft_strnlen.c
@@ -6,19 +6,19 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/15 15:30:54 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/02/15 15:43:15 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:18:11 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
 /**
- * @brief 文字列sを長さnまでのsの文字数を返します。
+ * @brief Returns the number of characters in string s up to length n. 
  *
  * @param s
  * @param n
  * @return size_t
- * @note ft_memchrで見つからなかった場合、nがそのまま返されます。
+ * @note If the return value of ft_memchr is NULL, return n.
  */
 size_t	ft_strnlen(const char *s, size_t n)
 {

--- a/lib/libft/get_next_line/get_next_line.c
+++ b/lib/libft/get_next_line/get_next_line.c
@@ -6,21 +6,21 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/12 11:07:44 by ttsubo            #+#    #+#             */
-/*   Updated: 2024/12/07 19:07:02 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:55:34 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "get_next_line.h"
 
 /**
- * @brief fd_buf内にあるバッファから1文字取り出しcpにセットします
- *
- * @param [out] fd_buf	: fd_buf 構造体
- * @param [out] cp		: 文字のポインタ
- * @retval PUTC_OK		: 文字の取り出しに成功
- * @retval PUTC_ERR		: 文字取り出し中にエラーになった
- * @retval PUTC_EOF		: EOFに達した
- * @note	<pre> fd_buf != NULL (呼出し側でfd_bufを設定する必要がある)
+ * @brief Takes one character out of the buffer and sets it in cp.
+ * 
+ * @param [out] fd_buf	: fd_buf
+ * @param [out] cp		: char pointer.
+ * @retval PUTC_OK		: Successfully retrieved the char.
+ * @retval PUTC_ERR		: Error while retrieving char.
+ * @retval PUTC_EOF		: EOF was reached.
+ * @note	<pre> fd_buf != NULL
  */
 static int	_ft_getc(t_buf *fd_buf, unsigned char *cp)
 {
@@ -42,13 +42,12 @@ static int	_ft_getc(t_buf *fd_buf, unsigned char *cp)
 }
 
 /**
- * @brief  string構造体に含まれるstrにcを追加します
- *
- * @param [out]	line	: 行情報を管理する構造体
- * @param [in]	c		: line.strに追加する文字
- * @param sts 			: getcの状態
- * @retval PUTC_OK		: lineにcを追加できた
- * @retval PUTC_ERR		: 追加する処理の途中でエラーになった
+ * @brief  Add c to t_string->str
+ * 
+ * @param line 
+ * @param c 
+ * @param sts 
+ * @return int 
  */
 static int	_ft_putc(t_string *line, char c, t_getc_sts sts)
 {
@@ -74,12 +73,11 @@ static int	_ft_putc(t_string *line, char c, t_getc_sts sts)
 }
 
 /**
- * @brief 対象のfd用バッファが未作成の場合に初期化します
- *
- * @param [out]	s_buf	: バッファ構造体のアドレス
- * @param [in]	fd		: ファイルディスクプリタ
- * @retval t_buf* 		: 初期化済みの構造体
- * @retval NULL 		: 初期化に失敗
+ * @brief Initialize t_buf. (but only if not yet created).
+ * 
+ * @param s_buf 
+ * @param fd 
+ * @return t_buf* 
  */
 static t_buf	*_gnl_buf_init(t_buf **s_buf, int fd)
 {
@@ -105,9 +103,9 @@ static t_buf	*_gnl_buf_init(t_buf **s_buf, int fd)
 }
 
 /**
- * @brief 渡されたバッファ構造体メモリを解放してNULLをセットします
+ * @brief free s_buf.
  *
- * @param [out]	s_buf	: メモリ解放するバッファ構造体
+ * @param [out]	s_buf
  */
 static void	_gnl_buf_free(t_buf **s_buf)
 {
@@ -126,10 +124,10 @@ static void	_gnl_buf_free(t_buf **s_buf)
 }
 
 /**
- * @brief fdから改行までの文字列を改行込みで取得します 
- * @param [in] fd	: ファイルディスクリプタ
- * @retval char* 	: fdから取得した改行を含む文字列
- * @retval NULL		: 読み込み失敗エラー 
+ * @brief Get string from fd to newline
+ * 
+ * @param fd 
+ * @return char* 
  */
 char	*get_next_line(int fd)
 {

--- a/lib/libft/get_next_line/get_next_line_bonus.c
+++ b/lib/libft/get_next_line/get_next_line_bonus.c
@@ -6,21 +6,21 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/12 11:07:44 by ttsubo            #+#    #+#             */
-/*   Updated: 2024/12/07 19:07:02 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:44:29 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "get_next_line_bonus.h"
 
 /**
- * @brief fd_buf内にあるバッファから1文字取り出しcpにセットします
- *
- * @param [out] fd_buf	: fd_buf 構造体
- * @param [out] cp		: 文字のポインタ
- * @retval PUTC_OK		: 文字の取り出しに成功
- * @retval PUTC_ERR		: 文字取り出し中にエラーになった
- * @retval PUTC_EOF		: EOFに達した
- * @note	<pre> fd_buf != NULL (呼出し側でfd_bufを設定する必要がある)
+ * @brief Takes one character out of the buffer and sets it in cp.
+ * 
+ * @param [out] fd_buf	: fd_buf
+ * @param [out] cp		: char pointer.
+ * @retval PUTC_OK		: Successfully retrieved the char.
+ * @retval PUTC_ERR		: Error while retrieving char.
+ * @retval PUTC_EOF		: EOF was reached.
+ * @note	<pre> fd_buf != NULL
  */
 static int	_ft_getc(t_buf *fd_buf, unsigned char *cp)
 {
@@ -42,13 +42,12 @@ static int	_ft_getc(t_buf *fd_buf, unsigned char *cp)
 }
 
 /**
- * @brief  string構造体に含まれるstrにcを追加します
- *
- * @param [out]	line	: 行情報を管理する構造体
- * @param [in]	c		: line.strに追加する文字
- * @param sts 			: getcの状態
- * @retval PUTC_OK		: lineにcを追加できた
- * @retval PUTC_ERR		: 追加する処理の途中でエラーになった
+ * @brief  Add c to t_string->str
+ * 
+ * @param line 
+ * @param c 
+ * @param sts 
+ * @return int 
  */
 static int	_ft_putc(t_string *line, char c, t_getc_sts sts)
 {
@@ -74,12 +73,11 @@ static int	_ft_putc(t_string *line, char c, t_getc_sts sts)
 }
 
 /**
- * @brief 対象のfd用バッファが未作成の場合に初期化します
- *
- * @param [out]	s_buf	: バッファ構造体のアドレス
- * @param [in]	fd		: ファイルディスクプリタ
- * @retval t_buf* 		: 初期化済みの構造体
- * @retval NULL 		: 初期化に失敗
+ * @brief Initialize t_buf. (but only if not yet created).
+ * 
+ * @param s_buf 
+ * @param fd 
+ * @return t_buf* 
  */
 static t_buf	*_gnl_buf_init(t_buf **s_buf, int fd)
 {
@@ -105,9 +103,9 @@ static t_buf	*_gnl_buf_init(t_buf **s_buf, int fd)
 }
 
 /**
- * @brief 渡されたバッファ構造体メモリを解放してNULLをセットします
+ * @brief free s_buf.
  *
- * @param [out]	s_buf	: メモリ解放するバッファ構造体
+ * @param [out]	s_buf
  */
 static void	_gnl_buf_free(t_buf **s_buf)
 {
@@ -126,10 +124,10 @@ static void	_gnl_buf_free(t_buf **s_buf)
 }
 
 /**
- * @brief fdから改行までの文字列を改行込みで取得します 
- * @param [in] fd	: ファイルディスクリプタ
- * @retval char* 	: fdから取得した改行を含む文字列
- * @retval NULL		: 読み込み失敗エラー 
+ * @brief Get string from fd to newline
+ * 
+ * @param fd 
+ * @return char* 
  */
 char	*get_next_line(int fd)
 {

--- a/lib/libft/get_next_line/get_next_line_utils.c
+++ b/lib/libft/get_next_line/get_next_line_utils.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/12 11:08:41 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/27 15:52:50 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 16:24:15 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,12 +90,12 @@ void	*gnl_line_free(t_string *line)
 	return (NULL);
 }
 
- /**
-  * @brief Sets the status of gnl.
-  * 
-  * @param status 
-  * @return t_sts* 
-  */
+/**
+ * @brief Sets the status of gnl.
+ * 
+ * @param status 
+ * @return t_sts* 
+ */
 t_sts	*set_sts(t_sts *status)
 {
 	if (status->getc_sts == GETC_OTHER && status->putc_sts == PUTC_OK)

--- a/lib/libft/get_next_line/get_next_line_utils.c
+++ b/lib/libft/get_next_line/get_next_line_utils.c
@@ -6,19 +6,19 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/12 11:08:41 by ttsubo            #+#    #+#             */
-/*   Updated: 2024/12/07 18:09:17 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:52:50 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "get_next_line.h"
 
 /**
- * @brief srcをdstに文字数srcsizeまでコピーします 
- *
- * @param [out] dst		: コピー先の文字列領域
- * @param [in]	src 	: コピーする文字列
- * @param [in]	srcsize	: コピーサイズ
- * @return char* 		: dstの先頭ポインタ
+ * @brief Copy src to dst up to the number of characters srcsize 
+ * 
+ * @param dst 
+ * @param src 
+ * @param srcsize 
+ * @return char* 
  */
 char	*gnl_strncpy(char *dst, const char *src, size_t srcsize)
 {
@@ -33,12 +33,12 @@ char	*gnl_strncpy(char *dst, const char *src, size_t srcsize)
 }
 
 /**
- * @brief メモリ領域bにサイズlenまでcの内容で埋めます
- *
- * @param b			: セットするメモリ領域
- * @param c			: セットする文字(255以上の上位ビットは無視されます)
- * @param len		: セットするサイズ
- * @return void*	: bのアドレス
+ * @brief Fill memory area b with the contents of c up to size len
+ * 
+ * @param b 
+ * @param c 
+ * @param len 
+ * @return void* 
  */
 void	*gnl_memset(void *b, int c, size_t len)
 {
@@ -53,11 +53,11 @@ void	*gnl_memset(void *b, int c, size_t len)
 }
 
 /**
- * @brief count * sizeのメモリ領域を0埋めした状態で確保します
+ * @brief Allocate a memory area of count * size filled with 0. 
  * 
- * @param count		: 確保するメモリ領域の個数 
- * @param size		: メモリ領域のサイズ
- * @return void*	: 確保したメモリ領域の先頭ポインタ 
+ * @param count 
+ * @param size 
+ * @return void* 
  */
 void	*gnl_calloc(size_t count, size_t size)
 {
@@ -75,10 +75,10 @@ void	*gnl_calloc(size_t count, size_t size)
 }
 
 /**
- * @brief lineの中の文字列を解放してNULLをセットします。
+ * @brief Releases the string in line and sets NULL.
  * 
- * @param line		: 行の情報を管理する構造体
- * @return void*	: NULLを返します
+ * @param line 
+ * @return void* 
  */
 void	*gnl_line_free(t_string *line)
 {
@@ -90,15 +90,12 @@ void	*gnl_line_free(t_string *line)
 	return (NULL);
 }
 
-/**
- * @brief putcとgetcの状態からgnlの状態を設定します
- *
- * @param [out]	status	: 状態管理用の構造体
- * @return t_sts*		: gnlの状態適用後のstatus
- * @note	GNL_READ	: 行読み取り中
- * @note	GNL_EOF		: EOFに達した
- * @note	GNL_ERR		: 処理中にエラーが発生
- */
+ /**
+  * @brief Sets the status of gnl.
+  * 
+  * @param status 
+  * @return t_sts* 
+  */
 t_sts	*set_sts(t_sts *status)
 {
 	if (status->getc_sts == GETC_OTHER && status->putc_sts == PUTC_OK)

--- a/lib/libft/get_next_line/get_next_line_utils_bonus.c
+++ b/lib/libft/get_next_line/get_next_line_utils_bonus.c
@@ -6,19 +6,19 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/12 11:08:41 by ttsubo            #+#    #+#             */
-/*   Updated: 2024/12/07 18:29:00 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:50:09 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "get_next_line_bonus.h"
 
 /**
- * @brief srcをdstに文字数srcsizeまでコピーします 
- *
- * @param [out] dst		: コピー先の文字列領域
- * @param [in]	src 	: コピーする文字列
- * @param [in]	srcsize	: コピーサイズ
- * @return char* 		: dstの先頭ポインタ
+ * @brief Copy src to dst up to the number of characters srcsize 
+ * 
+ * @param dst 
+ * @param src 
+ * @param srcsize 
+ * @return char* 
  */
 char	*gnl_strncpy(char *dst, const char *src, size_t srcsize)
 {
@@ -33,12 +33,12 @@ char	*gnl_strncpy(char *dst, const char *src, size_t srcsize)
 }
 
 /**
- * @brief メモリ領域bにサイズlenまでcの内容で埋めます
- *
- * @param b			: セットするメモリ領域
- * @param c			: セットする文字(255以上の上位ビットは無視されます)
- * @param len		: セットするサイズ
- * @return void*	: bのアドレス
+ * @brief Fill memory area b with the contents of c up to size len
+ * 
+ * @param b 
+ * @param c 
+ * @param len 
+ * @return void* 
  */
 void	*gnl_memset(void *b, int c, size_t len)
 {
@@ -53,11 +53,11 @@ void	*gnl_memset(void *b, int c, size_t len)
 }
 
 /**
- * @brief count * sizeのメモリ領域を0埋めした状態で確保します
+ * @brief Allocate a memory area of count * size filled with 0. 
  * 
- * @param count		: 確保するメモリ領域の個数 
- * @param size		: メモリ領域のサイズ
- * @return void*	: 確保したメモリ領域の先頭ポインタ 
+ * @param count 
+ * @param size 
+ * @return void* 
  */
 void	*gnl_calloc(size_t count, size_t size)
 {
@@ -75,10 +75,10 @@ void	*gnl_calloc(size_t count, size_t size)
 }
 
 /**
- * @brief lineの中の文字列を解放してNULLをセットします。
+ * @brief Releases the string in line and sets NULL.
  * 
- * @param line		: 行の情報を管理する構造体
- * @return void*	: NULLを返します
+ * @param line 
+ * @return void* 
  */
 void	*gnl_line_free(t_string *line)
 {
@@ -90,15 +90,12 @@ void	*gnl_line_free(t_string *line)
 	return (NULL);
 }
 
-/**
- * @brief putcとgetcの状態からgnlの状態を設定します
- *
- * @param [out]	status	: 状態管理用の構造体
- * @return t_sts*		: gnlの状態適用後のstatus
- * @note	GNL_READ	: 行読み取り中
- * @note	GNL_EOF		: EOFに達した
- * @note	GNL_ERR		: 処理中にエラーが発生
- */
+ /**
+  * @brief Sets the status of gnl.
+  * 
+  * @param status 
+  * @return t_sts* 
+  */
 t_sts	*set_sts(t_sts *status)
 {
 	if (status->getc_sts == GETC_OTHER && status->putc_sts == PUTC_OK)

--- a/lib/libft/get_next_line/get_next_line_utils_bonus.c
+++ b/lib/libft/get_next_line/get_next_line_utils_bonus.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/12 11:08:41 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/27 15:50:09 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 16:24:28 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,12 +90,12 @@ void	*gnl_line_free(t_string *line)
 	return (NULL);
 }
 
- /**
-  * @brief Sets the status of gnl.
-  * 
-  * @param status 
-  * @return t_sts* 
-  */
+/**
+ * @brief Sets the status of gnl.
+ * 
+ * @param status 
+ * @return t_sts* 
+ */
 t_sts	*set_sts(t_sts *status)
 {
 	if (status->getc_sts == GETC_OTHER && status->putc_sts == PUTC_OK)

--- a/src/builtin/builtin_utils.c
+++ b/src/builtin/builtin_utils.c
@@ -6,14 +6,14 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/20 19:46:40 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/20 20:01:04 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 14:55:58 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "main.h"
 
 /**
- * @brief "<name>: <mes>\n"形式でSTDERRに出力します。
+ * @brief Output to STDERR in the format "<name>: <mes>\n".
  *
  * @param name
  * @param mes

--- a/src/builtin/echo.c
+++ b/src/builtin/echo.c
@@ -6,18 +6,18 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 11:12:37 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/15 12:24:30 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 14:58:05 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "main.h"
 
 /**
- * @brief オプションがnのみか判定します
+ * @brief Determines if the option is n only. 
  *
- * @param arg1
- * @return 0: n以外が含まれている
- * @return 1: nのみ
+ * @param arg
+ * @return 0: Contains other than n
+ * @return 1: only n
  */
 static int	_has_only_n_option(char *arg)
 {
@@ -36,11 +36,11 @@ static int	_has_only_n_option(char *arg)
 }
 
 /**
- * @brief built-inのechoコマンドです。
+ * @brief The built-in echo command.
  *
  * @param argc
  * @param argv
- * @return 0: 常に0を返します。
+ * @return 0: Always returns 0.
  */
 int	builtin_echo(int argc, char *argv[])
 {

--- a/src/main.c
+++ b/src/main.c
@@ -6,14 +6,14 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/03 12:50:11 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/25 18:19:42 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 14:49:10 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "main.h"
 
 /**
- * @brief debug用　cmdを表示します。　後で削除予定。
+ * @brief [debug] show cmds. Delete later
  *
  * @param tokens
  */

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/03 12:50:11 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/27 14:49:10 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/28 11:55:41 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,8 +59,7 @@ static void	destroy_minish(t_minish *minish)
 }
 
 /**
- * @brief bool型が利用できるみたいなので、使用してみました。
- * @brief parse_command_lineのプロトタイプを勝手に作成しているので、好きなように改変していただいて大丈夫です
+ * @brief I used the bool type because it seems to be available.
  * @param program_nam
  * @param minish
  * @return true

--- a/src/minish_signal.c
+++ b/src/minish_signal.c
@@ -6,14 +6,14 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 13:35:06 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/05 14:46:39 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 14:54:18 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minish_signal.h"
 
 /**
- * @brief ctrl+cを押されたときのハンドラ関数
+ * @brief Handler function when ctrl+c is pressed 
  * 
  * @param signum 
  */
@@ -27,14 +27,10 @@ static void	ctrl_c(int signum)
 }
 
 /**
- * @brief sigaction構造体の値を設定します。
+ * @brief Sets the value of the sigaction structure
  * 
- * @param sa		: sigaction構造体
- * @param handler	: ハンドラ関数
- * @note sigaction構造体のうち、次の値を設定しています。
- * @note - sa_handler	:ハンドラ関数。引数fを設定します。NULLの場合はSIG_IGN。
- * @note - sa_mask		:ハンドラ実行中にブロックするマスク。ブロックはしない。
- * @note - sa_flags		:ハンドラの挙動を制御するフラグ。特に設定しない。
+ * @param sa		: sigaction structure
+ * @param handler	: handler funciton
  */
 static void	_set_sigaction(struct sigaction *sa, void (*handler)(int))
 {
@@ -47,9 +43,9 @@ static void	_set_sigaction(struct sigaction *sa, void (*handler)(int))
 }
 
 /**
- * @brief SIGINT(ctrl+c), SIGQUIT(ctrl+\)を設定します。
+ * @brief Sets SIGINT(ctrl+c) and SIGQUIT(ctrl+\).
  * 
- * @note ctrl+dはEOFのため、別途管理しています。
+ * @note ctrl+d is EOF, so it is managed separately.
  */
 void	minish_signal(void)
 {

--- a/src/tokenizer/get_token_capa.c
+++ b/src/tokenizer/get_token_capa.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 13:59:15 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/17 12:58:51 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 14:59:29 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,11 +34,11 @@ static t_token_type	_check_token_type(char c, int in_quote)
 }
 
 /**
- * @brief 文字列配列のキャパシティを計算します。
+ * @brief Calculates the capacity of a string array.
  *
  * @param str
  * @return size_t
- * @note 空白・リダイレクト・パイプの個数を求めています。
+ * @note Count the number of blanks, redirections, and pipes.
  */
 size_t	get_token_capa(char *str)
 {

--- a/src/tokenizer/is_quote_closed.c
+++ b/src/tokenizer/is_quote_closed.c
@@ -6,14 +6,14 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 13:59:15 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/15 16:28:32 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:16:12 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "tokenizer.h"
 
 /**
- * @brief ',"が閉じているか判定します。
+ * @brief Check if single and double quotes are closed.
  *
  * @param str
  * @return int

--- a/src/tokenizer/is_redirect_validate.c
+++ b/src/tokenizer/is_redirect_validate.c
@@ -6,17 +6,17 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 13:59:15 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/18 14:55:08 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:03:26 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "tokenizer.h"
 
 /**
- * @brief 正しいリダイレクトかチェックします。
+ * @brief Checks if the redirect symbol is a valid value.
  * @param str
  * @return int
- * @note 現状のチェックは連続したREDIRCTをチェックしています。
+ * @note For now, this function only checks for consecutive redirect symbols.
  */
 int	is_redirect_validate(char *str)
 {

--- a/src/tokenizer/tokenizer.c
+++ b/src/tokenizer/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 12:35:38 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/17 15:29:01 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/27 15:05:30 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ void	skip_spaces(t_tokenizer *tkn)
 }
 
 /**
- * @brief 生文字を意味のある単語単位で切り分けます。
+ * @brief Split a string into meaningful words.
  *
  * @param str
  * @return char**


### PR DESCRIPTION
fixed #158 
norm対策で日本語で書かれていたコメントを英語に変更しました。

テストコードについては提出に含めない予定なので対応していません。