### PR TITLE
終了ステータスを展開できるように変更

### DIFF
--- a/inc/parser.h
+++ b/inc/parser.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 14:14:59 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/26 11:48:11 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/29 12:17:18 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,7 @@
 # include "expand_env.h"
 
 t_cmd	**parser(char **tokens, t_minish *minish);
+void	set_cmd_type(t_cmd *cmd, char *token);
 size_t	cmds_len(t_cmd **cmds);
 int		is_separator(char *token);
 void	free_cmds(t_cmd **cmds, size_t count);

--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -6,11 +6,25 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 13:40:56 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/25 18:22:08 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/29 12:16:53 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
+
+void	set_cmd_type(t_cmd *cmd, char *token)
+{
+	if (!ft_strcmp(token, ">"))
+		cmd->type = REDIR_OUT;
+	else if (!ft_strcmp(token, ">>"))
+		cmd->type = REDIR_APPEND;
+	else if (!ft_strcmp(token, "<"))
+		cmd->type = REDIR_IN;
+	else if (!ft_strcmp(token, "<<"))
+		cmd->type = REDIR_HEREDOC;
+	else
+		cmd->type = REDIR_NONE;
+}
 
 size_t	cmds_len(t_cmd **cmds)
 {

--- a/src/parser/setup_cmds.c
+++ b/src/parser/setup_cmds.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 13:38:36 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/29 12:40:11 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/29 12:56:28 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,17 +32,22 @@ static int	_allocate_argv(t_cmd *cmd, char **tokens)
 
 static char	*_expand_dollar(char *str, t_minish *minish, size_t i)
 {
-	char	*dollar;
-	char	*join_str;
+	char	*pre;
+	char	*suf;
+	char	*sts_str;
+	char	*joined;
+	char	*final;
 
-	dollar = NULL;
-	if (str[i + 1] == '?')
+	if (str[i + 1] && str[i + 1] == '?')
 	{
-		dollar = ft_itoa(minish->last_status);
-		join_str = ft_strjoin(dollar, str + 2);
-		if (dollar)
-			free(dollar);
-		return (join_str);
+		pre = ft_substr(str, 0, i);
+		sts_str = ft_itoa(minish->last_status);
+		suf = ft_strdup(str + i + 2);
+		if (!pre || !sts_str || !suf)
+			return (free(pre), free(sts_str), free(suf), NULL);
+		joined = ft_strjoin(pre, sts_str);
+		final = ft_strjoin(joined, suf);
+		return (free(pre), free(sts_str), free(suf), free(joined), final);
 	}
 	else
 		return (expand_env(str, minish));
@@ -65,6 +70,8 @@ static char	*_expand_arg(char *token, t_minish *minish)
 		if (!is_squote && result[token_i] == '$')
 		{
 			expanded = _expand_dollar(result, minish, token_i);
+			if (!expanded)
+				return (result);
 			free(result);
 			result = expanded;
 			token_i = 0;

--- a/src/parser/setup_cmds.c
+++ b/src/parser/setup_cmds.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 13:38:36 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/26 21:11:33 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/29 12:20:28 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,18 +30,13 @@ static int	_allocate_argv(t_cmd *cmd, char **tokens)
 	return (0);
 }
 
-static void	_set_type(t_cmd *cmd, char *token)
+
+static char	*_expand_dollar(char *str, t_minish *minish, size_t i)
 {
-	if (!ft_strcmp(token, ">"))
-		cmd->type = REDIR_OUT;
-	else if (!ft_strcmp(token, ">>"))
-		cmd->type = REDIR_APPEND;
-	else if (!ft_strcmp(token, "<"))
-		cmd->type = REDIR_IN;
-	else if (!ft_strcmp(token, "<<"))
-		cmd->type = REDIR_HEREDOC;
+	if (str[i + 1] == '?')
+		return (ft_itoa(minish->last_status));
 	else
-		cmd->type = REDIR_NONE;
+		return (expand_env(str, minish));
 }
 
 static char	*_expand_arg(char *token, t_minish *minish)
@@ -49,7 +44,7 @@ static char	*_expand_arg(char *token, t_minish *minish)
 	size_t	token_i;
 	bool	is_squote;
 	char	*result;
-	char	*expaned;
+	char	*expanded;
 
 	token_i = 0;
 	is_squote = 0;
@@ -60,9 +55,9 @@ static char	*_expand_arg(char *token, t_minish *minish)
 			is_squote = !is_squote;
 		if (!is_squote && result[token_i] == '$')
 		{
-			expaned = expand_env(result, minish);
+			expanded = _expand_dollar(result, minish, token_i);
 			free(result);
-			result = expaned;
+			result = expanded;
 			token_i = 0;
 			continue ;
 		}
@@ -77,7 +72,7 @@ static void	_next_cmd(t_cmd **cmds, size_t *cmd_i, size_t *arg_i, char *token)
 	cmds[*cmd_i]->argc = *arg_i;
 	(*arg_i) = 0;
 	(*cmd_i)++;
-	_set_type(cmds[*cmd_i], token);
+	set_cmd_type(cmds[*cmd_i], token);
 	_allocate_argv(cmds[*cmd_i], &token);
 }
 
@@ -90,7 +85,7 @@ t_cmd	**setup_cmds(t_cmd **cmds, char **tokens, t_minish *minish)
 	token_i = 0;
 	cmd_i = 0;
 	arg_i = 0;
-	_set_type(cmds[0], tokens[token_i]);
+	set_cmd_type(cmds[0], tokens[token_i]);
 	_allocate_argv(cmds[0], tokens);
 	while (tokens[token_i])
 	{

--- a/src/parser/setup_cmds.c
+++ b/src/parser/setup_cmds.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 13:38:36 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/29 12:20:28 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/29 12:40:11 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,11 +30,20 @@ static int	_allocate_argv(t_cmd *cmd, char **tokens)
 	return (0);
 }
 
-
 static char	*_expand_dollar(char *str, t_minish *minish, size_t i)
 {
+	char	*dollar;
+	char	*join_str;
+
+	dollar = NULL;
 	if (str[i + 1] == '?')
-		return (ft_itoa(minish->last_status));
+	{
+		dollar = ft_itoa(minish->last_status);
+		join_str = ft_strjoin(dollar, str + 2);
+		if (dollar)
+			free(dollar);
+		return (join_str);
+	}
 	else
 		return (expand_env(str, minish));
 }

--- a/tests/parser/test_parser.c
+++ b/tests/parser/test_parser.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 14:28:00 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/26 20:55:04 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/29 12:57:29 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,7 +50,7 @@ int	main(int argc, char **argv, char **envp)
 		return (printf("usage: ./test_tokenizer.out <any message>"), 1);
 	tokens = tokenizer(argv[1]);
 	cmds = parser(tokens, minish);
-	if (!tokens)
+	if (!tokens || !cmds)
 		return (1);
 	i = 0;
 	while (cmds[i])


### PR DESCRIPTION
fixed #89 
パーサーで$?が展開するように対応しました。

```sh
./test_parser.out "cat \"\$?\" \$?\$SHELL\$SHELL"
        cmd->type=0
        cmd->argc=3
        cmd->argv=[cat,"0",0/bin/zsh/bin/zsh,NULL]
```