### PR TITLE
クオート閉じてなくても通常の文字として扱う形に修正

### DIFF
--- a/src/tokenizer/is_quote_closed.c
+++ b/src/tokenizer/is_quote_closed.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 13:59:15 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/27 15:16:12 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/29 14:57:34 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,9 +33,5 @@ int	is_quote_closed(char *str)
 			in_dquote = !in_dquote;
 		str++;
 	}
-	if (in_squote)
-		show_tokenizer_error(ERR_SQ_UNCLOSED);
-	if (in_dquote)
-		show_tokenizer_error(ERR_DQ_UNCLOSED);
 	return (!(in_squote || in_dquote));
 }

--- a/src/tokenizer/read_token.c
+++ b/src/tokenizer/read_token.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 16:33:33 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/25 22:20:42 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/29 15:20:11 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,8 @@ static char	*_read_quoted_token(t_tokenizer *tkn)
 	start = tkn->pos++;
 	while (tkn->input[tkn->pos] && tkn->input[tkn->pos] != quote)
 		tkn->pos++;
-	tkn->pos++;
+	if (tkn->input[tkn->pos] == quote)
+		tkn->pos++;
 	return (ft_substr(tkn->input, start, tkn->pos - start));
 }
 
@@ -44,6 +45,7 @@ static char	*_read_word_token(t_tokenizer *tkn)
 	start = tkn->pos;
 	while (tkn->input[tkn->pos]
 		&& !ft_isspace(tkn->input[tkn->pos])
+		&& !(tkn->input[tkn->pos] == '\'' || tkn->input[tkn->pos] == '"')
 		&& tkn->input[tkn->pos] != '|'
 		&& tkn->input[tkn->pos] != '>'
 		&& tkn->input[tkn->pos] != '<')

--- a/src/tokenizer/tokenizer.c
+++ b/src/tokenizer/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 12:35:38 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/27 15:05:30 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/04/29 14:58:23 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,8 +31,6 @@ char	**tokenizer(char *str)
 	t_tokenizer	tkn;
 
 	tkn = (t_tokenizer){.input = str, .pos = 0, .in_squote = 0, .in_dquote = 0};
-	if (!is_quote_closed(str))
-		return (NULL);
 	if (!is_redirect_validate(str))
 		return (NULL);
 	tokens = ft_calloc(get_token_capa(str) + 1, sizeof(char *));


### PR DESCRIPTION
fixed #172, #10
もともとクオートで閉じられていなかった場合エラーを出力していましたが、
課題要件に合わせるためエラーを出さないように修正しました。

### 確認例
```sh
./test_tokenizer.out "echo \"hoge fuga\" he's cool!'hello world'!"
token[0]=echo
token[1]="hoge fuga"
token[2]=he
token[3]='s cool!'
token[4]=hello
token[5]=world
token[6]='!
```