### PR TITLE
split_key_value分離

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: dayano <dayano@student.42.fr>              +#+  +:+       +#+         #
+#    By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/04/03 12:55:20 by ttsubo            #+#    #+#              #
-#    Updated: 2025/04/29 16:48:58 by dayano           ###   ########.fr        #
+#    Updated: 2025/05/01 14:29:53 by ttsubo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -57,7 +57,7 @@ PARSER_SRC		=	allocate_cmds.c  parser.c  parser_utils.c  setup_cmds.c \
 					expand_env.c
 BUILTIN_SRC		=	cd.c exit.c pwd.c echo.c env.c unset.c export.c \
 					env_utils.c env_utils_2.c env_utils_3.c builtin_utils.c \
-					export_exec.c export_print_sorted_env.c export_error.c
+					export_exec.c export_print_sorted_env.c export_error.c split_key_value.c
 
 # 3.Add more directories as they are added.
 $(eval $(call add_module,root))

--- a/inc/builtin_utils.h
+++ b/inc/builtin_utils.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/20 19:47:50 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/29 14:48:10 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/01 15:30:00 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,5 +27,6 @@ char		*ft_strndup(const char *s1, size_t n);
 int			export_exec(int argc, char **argv, t_minish *minish);
 int			print_sorted_env(t_env *head);
 void		export_err_invalid(char *sh, char *arg);
+int			split_key_value(char *str, char **key_out, char **val_out);
 
 #endif

--- a/inc/env_utils_2.h
+++ b/inc/env_utils_2.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/17 11:40:36 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/21 12:14:53 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/01 15:20:13 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,5 @@
 void	free_env_list(t_env *head);
 void	cleanup_minish(t_minish *minish);
 void	handle_error_and_exit(const char *func_name, t_minish *minish);
-int		split_key_value(char *str, char **key_out, char **val_out);
 
 #endif

--- a/src/builtin/env_utils_2.c
+++ b/src/builtin/env_utils_2.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/17 11:17:22 by dayano            #+#    #+#             */
-/*   Updated: 2025/04/28 16:32:00 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/01 14:27:15 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,52 +39,4 @@ void	handle_error_and_exit(const char *func_name, t_minish *minish)
 	cleanup_minish(minish);
 	perror(func_name);
 	exit(EXIT_FAILURE);
-}
-
-static void	_set_len_and_pos(char *str, size_t *key_len, size_t *val_start)
-{
-	const char	*sep;
-
-	sep = ft_strnstr(str, "+=", ft_strlen(str));
-	if (sep)
-	{
-		*key_len = sep - str;
-		*val_start = *key_len + 2;
-	}
-	else
-	{
-		sep = ft_strchr(str, '=');
-		if (sep)
-		{
-			*key_len = sep - str;
-			*val_start = *key_len + 1;
-		}
-		else
-		{
-			*key_len = ft_strlen(str);
-			*val_start = 0;
-		}
-	}
-}
-
-int	split_key_value(char *str, char **key_out, char **val_out)
-{
-	size_t	key_len;
-	size_t	val_start;
-
-	if (!str || !key_out || !val_out)
-		return (1);
-	*key_out = NULL;
-	*val_out = NULL;
-	_set_len_and_pos(str, &key_len, &val_start);
-	*key_out = ft_substr(str, 0, key_len);
-	if (!*key_out)
-		return (1);
-	if (val_start > 0)
-	{
-		*val_out = ft_substr(str, val_start, ft_strlen(str) - val_start);
-		if (!*val_out)
-			return (free(*key_out), *key_out = NULL, 1);
-	}
-	return (0);
 }

--- a/src/builtin/split_key_value.c
+++ b/src/builtin/split_key_value.c
@@ -1,0 +1,83 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   split_key_value.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/01 14:27:33 by ttsubo            #+#    #+#             */
+/*   Updated: 2025/05/01 14:54:33 by ttsubo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "main.h"
+
+static void	_set_len_and_pos(char *str, size_t *key_len, size_t *val_start)
+{
+	const char	*sep;
+
+	sep = ft_strnstr(str, "+=", ft_strlen(str));
+	if (sep)
+	{
+		*key_len = sep - str;
+		*val_start = *key_len + 2;
+	}
+	else
+	{
+		sep = ft_strchr(str, '=');
+		if (sep)
+		{
+			*key_len = sep - str;
+			*val_start = *key_len + 1;
+		}
+		else
+		{
+			*key_len = ft_strlen(str);
+			*val_start = 0;
+		}
+	}
+}
+
+static char	*_strip_quotes(char *str, size_t val_start)
+{
+	size_t	len;
+
+	if (!str)
+		return (NULL);
+	str = str + val_start;
+	len = ft_strlen(str);
+	if ((str[0] == '"' && str[len - 1] == '"')
+		|| (str[0] == '\'' && str[len - 1] == '\''))
+		return (ft_substr(str, 1, len - 2));
+	return (ft_strdup(str));
+}
+
+/**
+ * @brief e.g. "ABC=DEF" -> key_out=ABC, valout=DEF
+ * 
+ * @param str 
+ * @param key_out 
+ * @param val_out 
+ * @return int 
+ */
+int	split_key_value(char *str, char **key_out, char **val_out)
+{
+	size_t	key_len;
+	size_t	val_start;
+
+	if (!str || !key_out || !val_out)
+		return (1);
+	*key_out = NULL;
+	*val_out = NULL;
+	_set_len_and_pos(str, &key_len, &val_start);
+	*key_out = ft_substr(str, 0, key_len);
+	if (!*key_out)
+		return (1);
+	if (val_start > 0)
+	{
+		*val_out = _strip_quotes(str, val_start);
+		if (!*val_out)
+			return (free(*key_out), *key_out = NULL, 1);
+	}
+	return (0);
+}

--- a/src/initialize.c
+++ b/src/initialize.c
@@ -6,26 +6,29 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 15:42:46 by dayano            #+#    #+#             */
-/*   Updated: 2025/05/01 13:46:27 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/01 15:30:40 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "main.h"
 
-static int	_split_key_value(char *env_val, char **key_out, char **val_out)
+static int	_set_envp(char *env_val, t_env *node)
 {
 	size_t	env_len;
 	size_t	eq_pos;
 
 	env_len = ft_strlen(env_val);
 	eq_pos = ft_strlen_until(env_val, '=');
+	node->key = NULL;
+	node->value = NULL;
 	if (eq_pos == ft_strlen(env_val))
-		return (1);
-	*key_out = ft_substr(env_val, 0, eq_pos);
-	*val_out = ft_substr(env_val, eq_pos + 1, env_len - eq_pos - 1);
-	if (!*key_out || !*val_out)
-		return (1);
-	return (0);
+		return (0);
+	node->key = ft_substr(env_val, 0, eq_pos);
+	node->value = ft_substr(env_val, eq_pos + 1, env_len - eq_pos - 1);
+	if (!node->key || !node->value)
+		return (0);
+	node->is_exported = 1;
+	return (1);
 }
 
 static void	_free_node(t_env *node)
@@ -68,7 +71,7 @@ static t_env	*create_envp_list(char **envp)
 		node = ft_calloc(1, sizeof(t_env));
 		if (!node)
 			return (NULL);
-		if (_split_key_value(envp[i], &(node->key), &(node->value)))
+		if (!_set_envp(envp[i], node))
 			return (_free_nodes(&head), _free_node(node), NULL);
 		node->next = NULL;
 		if (!head)


### PR DESCRIPTION
fixed #193 

`export a="abc"`のとき、`a=""abc""`になっていましたが
`a="abc"`とクオートが取れた状態で環境変数に入れるように修正しました。
シングルクオートでも同様に動作します。

### 確認方法
`test_export.out`で確認可能です。
テスト確認用minishが起動しますので、export,envコマンドを利用してご確認ください。