### PR TITLE
argvのメモリ領域確保対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/04/03 12:55:20 by ttsubo            #+#    #+#              #
-#    Updated: 2025/05/02 16:16:40 by ttsubo           ###   ########.fr        #
+#    Updated: 2025/05/02 17:03:29 by ttsubo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -54,7 +54,7 @@ INVOKE_CMD_SRC	=	create_envp.c  exec_pipeline.c  execute_cmd.c \
 TOKENIZER_SRC	= 	tokenizer.c tokenizer_error.c read_token.c \
 					is_quote_closed.c get_token_capa.c is_redirect_validate.c
 PARSER_SRC		=	allocate_cmds.c  parser.c  parser_utils.c  setup_cmds.c \
-					expand_env.c
+					expand_env.c allocate_cmds_utils.c allocate_cmds_utils_2.c
 BUILTIN_SRC		=	cd.c exit.c pwd.c echo.c env.c unset.c export.c \
 					env_utils.c env_utils_2.c env_utils_3.c builtin_utils.c \
 					export_exec.c export_print_sorted_env.c export_error.c

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: dayano <dayano@student.42.fr>              +#+  +:+       +#+         #
+#    By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/04/03 12:55:20 by ttsubo            #+#    #+#              #
-#    Updated: 2025/04/29 16:48:58 by dayano           ###   ########.fr        #
+#    Updated: 2025/05/02 16:16:40 by ttsubo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -87,8 +87,8 @@ $(foreach DIR,$(MODULE_DIRS), \
 
 clean:
 	$(MAKE) -C $(FT_DIR) clean
-	find $(OBJ_DIR) -type f -name '*.o' -exec rm -f {} +
-	find $(OBJ_DIR) -type d -empty -not -name '.' -exec rmdir {} +
+	[ -d $(OBJ_DIR) ] && find $(OBJ_DIR) -type f -name '*.o' -exec rm -f {} + || true
+	[ -d $(OBJ_DIR) ] && find $(OBJ_DIR) -type d -empty -not -name '.' -exec rmdir {} + || true
 
 fclean:
 	$(MAKE) -C $(FT_DIR) fclean

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/04/03 12:55:20 by ttsubo            #+#    #+#              #
-#    Updated: 2025/05/02 17:20:26 by ttsubo           ###   ########.fr        #
+#    Updated: 2025/05/02 21:24:45 by ttsubo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -53,7 +53,7 @@ INVOKE_CMD_SRC	=	create_envp.c  exec_pipeline.c  execute_cmd.c \
 					redirect.c fds.c wait_pipeline.c
 TOKENIZER_SRC	= 	tokenizer.c tokenizer_error.c read_token.c \
 					is_quote_closed.c get_token_capa.c is_redirect_validate.c
-PARSER_SRC		=	allocate_cmds.c  parser.c  parser_utils.c  setup_cmds.c \
+PARSER_SRC		=	allocate_cmds.c  parser.c parser_free.c  parser_utils.c  setup_cmds.c \
 					allocate_cmds_utils.c allocate_cmds_utils_2.c \
 					expand_env.c expand_tokens.c
 BUILTIN_SRC		=	cd.c exit.c pwd.c echo.c env.c unset.c export.c \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/04/03 12:55:20 by ttsubo            #+#    #+#              #
-#    Updated: 2025/05/02 17:03:29 by ttsubo           ###   ########.fr        #
+#    Updated: 2025/05/02 17:20:26 by ttsubo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -54,7 +54,8 @@ INVOKE_CMD_SRC	=	create_envp.c  exec_pipeline.c  execute_cmd.c \
 TOKENIZER_SRC	= 	tokenizer.c tokenizer_error.c read_token.c \
 					is_quote_closed.c get_token_capa.c is_redirect_validate.c
 PARSER_SRC		=	allocate_cmds.c  parser.c  parser_utils.c  setup_cmds.c \
-					expand_env.c allocate_cmds_utils.c allocate_cmds_utils_2.c
+					allocate_cmds_utils.c allocate_cmds_utils_2.c \
+					expand_env.c expand_tokens.c
 BUILTIN_SRC		=	cd.c exit.c pwd.c echo.c env.c unset.c export.c \
 					env_utils.c env_utils_2.c env_utils_3.c builtin_utils.c \
 					export_exec.c export_print_sorted_env.c export_error.c

--- a/inc/parser.h
+++ b/inc/parser.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 14:14:59 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 17:19:32 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 17:56:17 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,6 @@ size_t	count_args_until_separator(char **tokens);
 int		is_separator(char *token);
 void	free_cmds(t_cmd **cmds, size_t count);
 t_cmd	**allocate_cmds(char **tokens);
-t_cmd	**setup_cmds(t_cmd **cmds, char **tokens, t_minish *minish);
+t_cmd	**setup_cmds(t_cmd **cmds, char **tokens);
 
 #endif

--- a/inc/parser.h
+++ b/inc/parser.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 14:14:59 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 17:56:17 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 21:25:06 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 # define PARSER_H
 
 # include "cmd.h"
+# include "parser_free.h"
 # include "expand_env.h"
 # include "libft.h"
 
@@ -30,7 +31,6 @@ void	set_cmd_type(t_cmd *cmd, char *token);
 size_t	cmds_len(t_cmd **cmds);
 size_t	count_args_until_separator(char **tokens);
 int		is_separator(char *token);
-void	free_cmds(t_cmd **cmds, size_t count);
 t_cmd	**allocate_cmds(char **tokens);
 t_cmd	**setup_cmds(t_cmd **cmds, char **tokens);
 

--- a/inc/parser.h
+++ b/inc/parser.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 14:14:59 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 16:59:11 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 17:19:32 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,8 @@
 # define PARSER_H
 
 # include "cmd.h"
-# include "libft.h"
 # include "expand_env.h"
+# include "libft.h"
 
 size_t	count_cmds(char **tokens);
 char	**next_cmd_start(char **token_ptr);
@@ -25,6 +25,7 @@ char	**calloc_argv(char **tokens);
 char	*calloc_arg(char *token);
 
 t_cmd	**parser(char **tokens, t_minish *minish);
+char	**expand_tokens(char **tokens, t_minish *minish);
 void	set_cmd_type(t_cmd *cmd, char *token);
 size_t	cmds_len(t_cmd **cmds);
 size_t	count_args_until_separator(char **tokens);

--- a/inc/parser.h
+++ b/inc/parser.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 14:14:59 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/29 12:17:18 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 16:14:02 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,11 @@
 # include "cmd.h"
 # include "libft.h"
 # include "expand_env.h"
+
+t_cmd	**calloc_cmds(char **tokens);
+t_cmd	*calloc_cmd(void);
+char	**calloc_argv(char **tokens);
+char	*calloc_arg(char *token);
 
 t_cmd	**parser(char **tokens, t_minish *minish);
 void	set_cmd_type(t_cmd *cmd, char *token);

--- a/inc/parser.h
+++ b/inc/parser.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 14:14:59 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 16:14:02 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 16:59:11 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,8 @@
 # include "libft.h"
 # include "expand_env.h"
 
+size_t	count_cmds(char **tokens);
+char	**next_cmd_start(char **token_ptr);
 t_cmd	**calloc_cmds(char **tokens);
 t_cmd	*calloc_cmd(void);
 char	**calloc_argv(char **tokens);
@@ -25,6 +27,7 @@ char	*calloc_arg(char *token);
 t_cmd	**parser(char **tokens, t_minish *minish);
 void	set_cmd_type(t_cmd *cmd, char *token);
 size_t	cmds_len(t_cmd **cmds);
+size_t	count_args_until_separator(char **tokens);
 int		is_separator(char *token);
 void	free_cmds(t_cmd **cmds, size_t count);
 t_cmd	**allocate_cmds(char **tokens);

--- a/inc/parser_free.h
+++ b/inc/parser_free.h
@@ -1,0 +1,20 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser_free.h                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/02 21:22:56 by ttsubo            #+#    #+#             */
+/*   Updated: 2025/05/02 21:27:46 by ttsubo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef PARSER_FREE_H
+# define PARSER_FREE_H
+
+void	free_tokens(char **tokens);
+void	free_cmd(t_cmd *cmd);
+void	free_cmds(t_cmd **cmds);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/03 12:50:11 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 20:30:23 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 21:25:49 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,7 +61,7 @@ static bool	prompt(char *program_name, t_minish *minish)
 	if (cmds[0]->argc > 0)
 		minish->last_status = invoke_commands(cmds[0], minish);
 	_free_tokens(tokens);
-	free_cmds(cmds, cmds_len(cmds));
+	free_cmds(cmds);
 	free(line);
 	return (true);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/03 12:50:11 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/29 13:06:39 by dayano           ###   ########.fr       */
+/*   Updated: 2025/05/02 20:30:23 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,7 @@ int	main(int argc, char **argv, char **envp)
 {
 	t_minish	*minish;
 	char		*program_name;
+	int			last_status;
 
 	(void)argc;
 	program_name = argv[0];
@@ -77,6 +78,7 @@ int	main(int argc, char **argv, char **envp)
 	minish_signal();
 	while (prompt(program_name, minish))
 		;
+	last_status = minish->last_status;
 	destroy_minish(minish);
-	return (minish->last_status);
+	return (last_status);
 }

--- a/src/parser/allocate_cmds.c
+++ b/src/parser/allocate_cmds.c
@@ -6,56 +6,69 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 12:19:28 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/26 20:39:41 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 17:02:35 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
 
-static size_t	_count_cmds(char **tokens)
+static int	_allocate_argv(t_cmd *cmd, char **token_ptr)
 {
-	size_t	i;
-	size_t	cmd_count;
+	size_t	arg_i;
+	size_t	len;
 
-	i = 0;
-	cmd_count = 1;
-	while (tokens[i])
+	cmd->argv = calloc_argv(token_ptr);
+	if (!cmd->argv)
+		return (1);
+	arg_i = 0;
+	len = count_args_until_separator(token_ptr);
+	while (arg_i < len)
 	{
-		if (is_separator(tokens[i]))
-			cmd_count++;
-		i++;
+		cmd->argv[arg_i] = calloc_arg(token_ptr[arg_i]);
+		if (!cmd->argv[arg_i])
+		{
+			while (0 < arg_i)
+				free(cmd->argv[--arg_i]);
+			free(cmd->argv);
+			return (1);
+		}
+		arg_i++;
 	}
-	return (cmd_count);
+	return (0);
 }
 
-static t_cmd	**_allocate_cmds(size_t count)
+static t_cmd	*_allocate_cmd(char **token_ptr)
 {
-	size_t	i;
-	t_cmd	**cmds;
+	t_cmd	*cmd;
 
-	i = 0;
-	cmds = ft_calloc(count + 1, sizeof(t_cmd *));
-	if (!cmds)
+	cmd = calloc_cmd();
+	if (!cmd)
 		return (NULL);
-	while (i < count)
-	{
-		cmds[i] = ft_calloc(1, sizeof(t_cmd));
-		if (!cmds[i])
-			return (free_cmds(cmds, i), NULL);
-		if (i > 0)
-			cmds[i - 1]->next = cmds[i];
-		i++;
-	}
-	cmds[i] = NULL;
-	return (cmds);
+	if (_allocate_argv(cmd, token_ptr))
+		return (free(cmd), NULL);
+	return (cmd);
 }
 
 t_cmd	**allocate_cmds(char **tokens)
 {
+	char	**token_ptr;
 	t_cmd	**cmds;
+	size_t	cmd_i;
+	size_t	len;
 
-	cmds = _allocate_cmds(_count_cmds(tokens));
+	cmds = calloc_cmds(tokens);
 	if (!cmds)
 		return (NULL);
+	cmd_i = 0;
+	len = count_cmds(tokens);
+	token_ptr = tokens;
+	while (cmd_i < len)
+	{
+		cmds[cmd_i] = _allocate_cmd(token_ptr);
+		if (!cmds[cmd_i])
+			return (free_cmds(cmds, cmd_i), NULL);
+		token_ptr = next_cmd_start(token_ptr);
+		cmd_i++;
+	}
 	return (cmds);
 }

--- a/src/parser/allocate_cmds.c
+++ b/src/parser/allocate_cmds.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 12:19:28 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 18:43:34 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 21:26:21 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,7 +66,7 @@ t_cmd	**allocate_cmds(char **tokens)
 	{
 		cmds[cmd_i] = _allocate_cmd(token_ptr);
 		if (!cmds[cmd_i])
-			return (free_cmds(cmds, cmd_i), NULL);
+			return (free_cmds(cmds), NULL);
 		if (cmd_i > 0)
 			cmds[cmd_i - 1]->next = cmds[cmd_i];
 		token_ptr = next_cmd_start(token_ptr);

--- a/src/parser/allocate_cmds.c
+++ b/src/parser/allocate_cmds.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 12:19:28 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 17:02:35 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 18:43:34 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,6 +67,8 @@ t_cmd	**allocate_cmds(char **tokens)
 		cmds[cmd_i] = _allocate_cmd(token_ptr);
 		if (!cmds[cmd_i])
 			return (free_cmds(cmds, cmd_i), NULL);
+		if (cmd_i > 0)
+			cmds[cmd_i - 1]->next = cmds[cmd_i];
 		token_ptr = next_cmd_start(token_ptr);
 		cmd_i++;
 	}

--- a/src/parser/allocate_cmds_utils.c
+++ b/src/parser/allocate_cmds_utils.c
@@ -1,0 +1,51 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   allocate_cmds_utils.c                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/24 12:19:28 by ttsubo            #+#    #+#             */
+/*   Updated: 2025/05/02 16:12:47 by ttsubo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "parser.h"
+
+t_cmd	**calloc_cmds(char **tokens)
+{
+	t_cmd	**cmds;
+	size_t	cmd_i;
+	size_t	token_i;
+
+	token_i = 0;
+	cmd_i = 1;
+	while (tokens[token_i])
+	{
+		if (is_separator(tokens[token_i]))
+			cmd_i++;
+		token_i++;
+	}
+	cmds = ft_calloc(sizeof(t_cmd*), cmd_i + 1);
+	return (cmds);
+}
+
+t_cmd	*calloc_cmd(void)
+{
+	return (ft_calloc(sizeof(t_cmd), 1));
+}
+
+char	**calloc_argv(char **tokens)
+{
+	size_t	token_i;
+
+	token_i = 0;
+	while (tokens[token_i] && !is_separator(tokens[token_i]))
+		token_i++;
+	return (ft_calloc(sizeof(char *), token_i + 1));
+}
+
+char	*calloc_arg(char *token)
+{
+	return (ft_strdup(token));
+}

--- a/src/parser/allocate_cmds_utils.c
+++ b/src/parser/allocate_cmds_utils.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 12:19:28 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 16:35:17 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 18:12:06 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,8 @@ char	**next_cmd_start(char **token_ptr)
 
 	token_i = 0;
 	while (token_ptr[token_i] && !is_separator(token_ptr[token_i]))
+		token_i++;
+	if (token_ptr[token_i])
 		token_i++;
 	return (&token_ptr[token_i]);
 }

--- a/src/parser/allocate_cmds_utils.c
+++ b/src/parser/allocate_cmds_utils.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 12:19:28 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 16:12:47 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 16:17:27 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ t_cmd	**calloc_cmds(char **tokens)
 			cmd_i++;
 		token_i++;
 	}
-	cmds = ft_calloc(sizeof(t_cmd*), cmd_i + 1);
+	cmds = ft_calloc(sizeof(t_cmd *), cmd_i + 1);
 	return (cmds);
 }
 

--- a/src/parser/allocate_cmds_utils.c
+++ b/src/parser/allocate_cmds_utils.c
@@ -6,11 +6,21 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 12:19:28 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 16:17:27 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 16:35:17 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
+
+char	**next_cmd_start(char **token_ptr)
+{
+	size_t	token_i;
+
+	token_i = 0;
+	while (token_ptr[token_i] && !is_separator(token_ptr[token_i]))
+		token_i++;
+	return (&token_ptr[token_i]);
+}
 
 t_cmd	**calloc_cmds(char **tokens)
 {

--- a/src/parser/allocate_cmds_utils_2.c
+++ b/src/parser/allocate_cmds_utils_2.c
@@ -1,0 +1,29 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   allocate_cmds_utils_2.c                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/24 12:19:28 by ttsubo            #+#    #+#             */
+/*   Updated: 2025/05/02 16:58:45 by ttsubo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "parser.h"
+
+size_t	count_cmds(char **tokens)
+{
+	size_t	i;
+	size_t	count;
+
+	i = 0;
+	count = 1;
+	while (tokens[i])
+	{
+		if (is_separator(tokens[i]))
+			count++;
+		i++;
+	}
+	return (count);
+}

--- a/src/parser/expand_tokens.c
+++ b/src/parser/expand_tokens.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/02 17:08:42 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 17:22:05 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 17:52:43 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,49 @@ static size_t	_tokens_len(char **tokens)
 	return (i);
 }
 
+/**
+ * @note pre: $? in str
+ */
+static char	*_expand_dollar(char *str, t_minish *minish)
+{
+	char	*pre;
+	char	*suf;
+	char	*sts_str;
+	char	*joined;
+	char	*final;
+
+	pre = ft_substr(str, 0, ft_strlen_until(str, '$'));
+	sts_str = ft_itoa(minish->last_status);
+	suf = ft_strdup(str + ft_strlen_until(str, '$') + 2);
+	if (!pre || !sts_str || !suf)
+		return (free(pre), free(sts_str), free(suf), NULL);
+	joined = ft_strjoin(pre, sts_str);
+	final = ft_strjoin(joined, suf);
+	return (free(pre), free(sts_str), free(suf), free(joined), final);
+}
+
+static char	*_expand(char *token, t_minish *minish)
+{
+	char	*result;
+	char	*tmp;
+
+	result = ft_strdup(token);
+	if (!result)
+		return (NULL);
+	while (ft_strchr(result, '$'))
+	{
+		tmp = result;
+		if (ft_strnstr(result, "$?", ft_strlen(result)))
+			result = _expand_dollar(tmp, minish);
+		else
+			result = expand_env(tmp, minish);
+		free(tmp);
+		if (!result)
+			return (NULL);
+	}
+	return (result);
+}
+
 char	**expand_tokens(char **tokens, t_minish *minish)
 {
 	size_t	token_i;
@@ -35,7 +78,7 @@ char	**expand_tokens(char **tokens, t_minish *minish)
 	token_i = 0;
 	while (token_i < len)
 	{
-		expanded[token_i] = expand_env(tokens[token_i], minish);
+		expanded[token_i] = _expand(tokens[token_i], minish);
 		if (!expanded[token_i])
 		{
 			while (0 < token_i)

--- a/src/parser/expand_tokens.c
+++ b/src/parser/expand_tokens.c
@@ -1,0 +1,49 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand_tokens.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/02 17:08:42 by ttsubo            #+#    #+#             */
+/*   Updated: 2025/05/02 17:22:05 by ttsubo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "parser.h"
+
+static size_t	_tokens_len(char **tokens)
+{
+	size_t	i;
+
+	i = 0;
+	while (tokens[i])
+		i++;
+	return (i);
+}
+
+char	**expand_tokens(char **tokens, t_minish *minish)
+{
+	size_t	token_i;
+	size_t	len;
+	char	**expanded;
+
+	len = _tokens_len(tokens);
+	expanded = ft_calloc(sizeof(char *), len + 1);
+	if (!expanded)
+		return (NULL);
+	token_i = 0;
+	while (token_i < len)
+	{
+		expanded[token_i] = expand_env(tokens[token_i], minish);
+		if (!expanded[token_i])
+		{
+			while (0 < token_i)
+				free(expanded[--token_i]);
+			free(expanded);
+			return (NULL);
+		}
+		token_i++;
+	}
+	return (expanded);
+}

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,23 +6,11 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 14:14:32 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 19:08:14 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 21:27:58 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
-
-static void	_free_tokens(char **tokens)
-{
-	size_t	token_i;
-
-	token_i = 0;
-	while (tokens[token_i])
-		token_i++;
-	while (0 < token_i)
-		free(tokens[--token_i]);
-	free(tokens);
-}
 
 /**
  * @brief
@@ -40,10 +28,10 @@ t_cmd	**parser(char **tokens, t_minish *minish)
 		return (NULL);
 	cmds = allocate_cmds(expanded_tokens);
 	if (!cmds)
-		return (_free_tokens(expanded_tokens), NULL);
+		return (free_tokens(expanded_tokens), NULL);
 	cmds = setup_cmds(cmds, expanded_tokens);
 	if (!cmds)
-		return (_free_tokens(expanded_tokens), NULL);
-	_free_tokens(expanded_tokens);
+		return (free_tokens(expanded_tokens), NULL);
+	free_tokens(expanded_tokens);
 	return (cmds);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 14:14:32 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 17:18:40 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 17:55:50 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ t_cmd	**parser(char **tokens, t_minish *minish)
 	cmds = allocate_cmds(expanded_tokens);
 	if (!cmds)
 		return (NULL);
-	cmds = setup_cmds(cmds, expanded_tokens, minish);
+	cmds = setup_cmds(cmds, expanded_tokens);
 	if (!cmds)
 		return (NULL);
 	return (cmds);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,11 +6,23 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 14:14:32 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 17:55:50 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 19:08:14 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
+
+static void	_free_tokens(char **tokens)
+{
+	size_t	token_i;
+
+	token_i = 0;
+	while (tokens[token_i])
+		token_i++;
+	while (0 < token_i)
+		free(tokens[--token_i]);
+	free(tokens);
+}
 
 /**
  * @brief
@@ -28,9 +40,10 @@ t_cmd	**parser(char **tokens, t_minish *minish)
 		return (NULL);
 	cmds = allocate_cmds(expanded_tokens);
 	if (!cmds)
-		return (NULL);
+		return (_free_tokens(expanded_tokens), NULL);
 	cmds = setup_cmds(cmds, expanded_tokens);
 	if (!cmds)
-		return (NULL);
+		return (_free_tokens(expanded_tokens), NULL);
+	_free_tokens(expanded_tokens);
 	return (cmds);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,26 +6,30 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 14:14:32 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/26 11:48:00 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 17:18:40 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
 
 /**
- * @brief 
- * 
- * @param tokens 
- * @return t_cmd** 
+ * @brief
+ *
+ * @param tokens
+ * @return t_cmd**
  */
 t_cmd	**parser(char **tokens, t_minish *minish)
 {
+	char	**expanded_tokens;
 	t_cmd	**cmds;
 
-	cmds = allocate_cmds(tokens);
+	expanded_tokens = expand_tokens(tokens, minish);
+	if (!expanded_tokens)
+		return (NULL);
+	cmds = allocate_cmds(expanded_tokens);
 	if (!cmds)
 		return (NULL);
-	cmds = setup_cmds(cmds, tokens, minish);
+	cmds = setup_cmds(cmds, expanded_tokens, minish);
 	if (!cmds)
 		return (NULL);
 	return (cmds);

--- a/src/parser/parser_free.c
+++ b/src/parser/parser_free.c
@@ -1,0 +1,46 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser_free.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/02 20:55:39 by ttsubo            #+#    #+#             */
+/*   Updated: 2025/05/02 21:28:08 by ttsubo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "parser.h"
+
+void	free_tokens(char **tokens)
+{
+	size_t	token_i;
+
+	token_i = 0;
+	while (tokens && tokens[token_i])
+		token_i++;
+	while (0 < token_i)
+		free(tokens[--token_i]);
+	free(tokens);
+}
+
+void	free_cmd(t_cmd *cmd)
+{
+	size_t	arg_i;
+
+	arg_i = 0;
+	while (cmd->argv && cmd->argv[arg_i])
+		free(cmd->argv[arg_i++]);
+	free(cmd->argv);
+	free(cmd);
+}
+
+void	free_cmds(t_cmd **cmds)
+{
+	size_t	cmd_i;
+
+	cmd_i = 0;
+	while (cmds[cmd_i])
+		free_cmd(cmds[cmd_i++]);
+	free(cmds);
+}

--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 13:40:56 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/29 12:16:53 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 16:48:32 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,16 @@ void	set_cmd_type(t_cmd *cmd, char *token)
 		cmd->type = REDIR_HEREDOC;
 	else
 		cmd->type = REDIR_NONE;
+}
+
+size_t	count_args_until_separator(char **tokens)
+{
+	size_t	i;
+
+	i = 0;
+	while (tokens[i] && !is_separator(tokens[i]))
+		i++;
+	return (i);
 }
 
 size_t	cmds_len(t_cmd **cmds)

--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 13:40:56 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 16:48:32 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 21:26:41 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,24 +44,6 @@ size_t	cmds_len(t_cmd **cmds)
 	while (cmds[i])
 		i++;
 	return (i);
-}
-
-void	free_cmds(t_cmd **cmds, size_t count)
-{
-	size_t	cmd_i;
-	size_t	arg_i;
-
-	cmd_i = 0;
-	while (cmd_i < count)
-	{
-		arg_i = 0;
-		while (cmds[cmd_i]->argv && cmds[cmd_i]->argv[arg_i])
-			free(cmds[cmd_i]->argv[arg_i++]);
-		free(cmds[cmd_i]->argv);
-		free(cmds[cmd_i]);
-		cmd_i++;
-	}
-	free(cmds);
 }
 
 int	is_separator(char *token)

--- a/src/parser/setup_cmds.c
+++ b/src/parser/setup_cmds.c
@@ -6,81 +6,11 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 13:38:36 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/29 12:56:28 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 17:55:38 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
-
-static int	_allocate_argv(t_cmd *cmd, char **tokens)
-{
-	size_t	token_i;
-	size_t	argc;
-
-	token_i = 0;
-	argc = 0;
-	while (tokens[token_i] && !is_separator(tokens[token_i]))
-	{
-		token_i++;
-		argc++;
-	}
-	cmd->argv = ft_calloc(argc + 1, sizeof(char *));
-	if (!cmd->argv)
-		return (1);
-	return (0);
-}
-
-static char	*_expand_dollar(char *str, t_minish *minish, size_t i)
-{
-	char	*pre;
-	char	*suf;
-	char	*sts_str;
-	char	*joined;
-	char	*final;
-
-	if (str[i + 1] && str[i + 1] == '?')
-	{
-		pre = ft_substr(str, 0, i);
-		sts_str = ft_itoa(minish->last_status);
-		suf = ft_strdup(str + i + 2);
-		if (!pre || !sts_str || !suf)
-			return (free(pre), free(sts_str), free(suf), NULL);
-		joined = ft_strjoin(pre, sts_str);
-		final = ft_strjoin(joined, suf);
-		return (free(pre), free(sts_str), free(suf), free(joined), final);
-	}
-	else
-		return (expand_env(str, minish));
-}
-
-static char	*_expand_arg(char *token, t_minish *minish)
-{
-	size_t	token_i;
-	bool	is_squote;
-	char	*result;
-	char	*expanded;
-
-	token_i = 0;
-	is_squote = 0;
-	result = ft_strdup(token);
-	while (result[token_i])
-	{
-		if (result[token_i] == '\'')
-			is_squote = !is_squote;
-		if (!is_squote && result[token_i] == '$')
-		{
-			expanded = _expand_dollar(result, minish, token_i);
-			if (!expanded)
-				return (result);
-			free(result);
-			result = expanded;
-			token_i = 0;
-			continue ;
-		}
-		token_i++;
-	}
-	return (result);
-}
 
 static void	_next_cmd(t_cmd **cmds, size_t *cmd_i, size_t *arg_i, char *token)
 {
@@ -89,10 +19,9 @@ static void	_next_cmd(t_cmd **cmds, size_t *cmd_i, size_t *arg_i, char *token)
 	(*arg_i) = 0;
 	(*cmd_i)++;
 	set_cmd_type(cmds[*cmd_i], token);
-	_allocate_argv(cmds[*cmd_i], &token);
 }
 
-t_cmd	**setup_cmds(t_cmd **cmds, char **tokens, t_minish *minish)
+t_cmd	**setup_cmds(t_cmd **cmds, char **tokens)
 {
 	size_t	token_i;
 	size_t	cmd_i;
@@ -102,18 +31,12 @@ t_cmd	**setup_cmds(t_cmd **cmds, char **tokens, t_minish *minish)
 	cmd_i = 0;
 	arg_i = 0;
 	set_cmd_type(cmds[0], tokens[token_i]);
-	_allocate_argv(cmds[0], tokens);
 	while (tokens[token_i])
 	{
 		if (is_separator(tokens[token_i]))
 			_next_cmd(cmds, &cmd_i, &arg_i, tokens[token_i]);
 		else
-		{
-			cmds[cmd_i]->argv[arg_i] = _expand_arg(tokens[token_i], minish);
-			if (!cmds[cmd_i]->argv[arg_i])
-				return (free_cmds(cmds, cmds_len(cmds)), NULL);
-			arg_i++;
-		}
+			cmds[cmd_i]->argv[arg_i++] = tokens[token_i];
 		token_i++;
 	}
 	cmds[cmd_i]->argc = arg_i;

--- a/src/parser/setup_cmds.c
+++ b/src/parser/setup_cmds.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 13:38:36 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 17:55:38 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 18:18:00 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,6 +40,5 @@ t_cmd	**setup_cmds(t_cmd **cmds, char **tokens)
 		token_i++;
 	}
 	cmds[cmd_i]->argc = arg_i;
-	cmds[++cmd_i] = NULL;
 	return (cmds);
 }

--- a/src/parser/setup_cmds.c
+++ b/src/parser/setup_cmds.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 13:38:36 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 18:18:00 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 18:59:44 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,7 +36,12 @@ t_cmd	**setup_cmds(t_cmd **cmds, char **tokens)
 		if (is_separator(tokens[token_i]))
 			_next_cmd(cmds, &cmd_i, &arg_i, tokens[token_i]);
 		else
-			cmds[cmd_i]->argv[arg_i++] = tokens[token_i];
+		{
+			cmds[cmd_i]->argv[arg_i] = ft_strdup(tokens[token_i]);
+			if (!cmds[cmd_i]->argv[arg_i])
+				return (free_cmds(cmds, cmd_i), NULL);
+			arg_i++;
+		}
 		token_i++;
 	}
 	cmds[cmd_i]->argc = arg_i;

--- a/src/parser/setup_cmds.c
+++ b/src/parser/setup_cmds.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 13:38:36 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/02 18:59:44 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/02 21:26:54 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,7 @@ t_cmd	**setup_cmds(t_cmd **cmds, char **tokens)
 		{
 			cmds[cmd_i]->argv[arg_i] = ft_strdup(tokens[token_i]);
 			if (!cmds[cmd_i]->argv[arg_i])
-				return (free_cmds(cmds, cmd_i), NULL);
+				return (free_cmds(cmds), NULL);
 			arg_i++;
 		}
 		token_i++;


### PR DESCRIPTION
fixed #198 

メモリの確保が正しくできていなかったので、parserの内部処理を作り直しました。
インターフェース部分に変更はないのでinvoke_cmdはそのまま使えます。

メモリリークが発生していますが、
こちらの対応については #207 でまとめて行うので、ここでは残したままとさせてください。