### PR TITLE
tokenizerのquote処理見直し

### DIFF
--- a/src/tokenizer/read_token.c
+++ b/src/tokenizer/read_token.c
@@ -6,24 +6,15 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 16:33:33 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/29 15:20:11 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/05 13:02:17 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "tokenizer.h"
 
-static char	*_read_quoted_token(t_tokenizer *tkn)
+static int	_is_token_end(char c)
 {
-	char	quote;
-	int		start;
-
-	quote = tkn->input[tkn->pos];
-	start = tkn->pos++;
-	while (tkn->input[tkn->pos] && tkn->input[tkn->pos] != quote)
-		tkn->pos++;
-	if (tkn->input[tkn->pos] == quote)
-		tkn->pos++;
-	return (ft_substr(tkn->input, start, tkn->pos - start));
+	return (ft_isspace(c) || c == '|' || c == '<' || c == '>' || c == '\0');
 }
 
 static char	*_read_op_token(t_tokenizer *tkn)
@@ -40,16 +31,23 @@ static char	*_read_op_token(t_tokenizer *tkn)
 
 static char	*_read_word_token(t_tokenizer *tkn)
 {
-	int	start;
+	int		start;
+	char	quote;
 
 	start = tkn->pos;
-	while (tkn->input[tkn->pos]
-		&& !ft_isspace(tkn->input[tkn->pos])
-		&& !(tkn->input[tkn->pos] == '\'' || tkn->input[tkn->pos] == '"')
-		&& tkn->input[tkn->pos] != '|'
-		&& tkn->input[tkn->pos] != '>'
-		&& tkn->input[tkn->pos] != '<')
-		tkn->pos++;
+	while (!_is_token_end(tkn->input[tkn->pos]))
+	{
+		if (tkn->input[tkn->pos] == '\'' || tkn->input[tkn->pos] == '"')
+		{
+			quote = tkn->input[tkn->pos++];
+			while (tkn->input[tkn->pos] && tkn->input[tkn->pos] != quote)
+				tkn->pos++;
+			if (tkn->input[tkn->pos] == quote)
+				tkn->pos++;
+		}
+		else
+			tkn->pos++;
+	}
 	return (ft_substr(tkn->input, start, tkn->pos - start));
 }
 
@@ -63,8 +61,6 @@ char	*read_token(t_tokenizer *tkn)
 {
 	char	*op;
 
-	if (tkn->input[tkn->pos] == '\'' || tkn->input[tkn->pos] == '"')
-		return (_read_quoted_token(tkn));
 	op = _read_op_token(tkn);
 	if (op)
 		return (op);


### PR DESCRIPTION
fixed #213

### 概要
tokenizerが元々`"a""b"`を`["a","b"]`別トークンで扱っていたのを`["\"a\"\b\""]`という形で一つのトークンにまとめる形にしました。

クオートをなくす処理についてはParserの責務ですので、このプルリクエストでは対応していません。
詳しくはｰ>#200

### 確認方法
`make`後`./minish`で確認で動作可能ですが、効果を確認するのは難しいです。
一応対応前後でechoの挙動が変わります。
- 修正前: `echo "a""b" -> "a" "b"` ※token区切りでスペースを入れて出力しているため、修正前はスペースが入る
- 修正後: `echo "a""b" -> "a""b"`