### PR TITLE
プロンプト入力中にシグナルを受け取ると終了ステータスが更新されるようになる対応

### DIFF
--- a/inc/common/struct.h
+++ b/inc/common/struct.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 17:10:22 by dayano            #+#    #+#             */
-/*   Updated: 2025/05/04 19:16:10 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/08 16:53:17 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,13 @@
 # define STRUCT_H
 
 # include <sys/wait.h>
+
+typedef enum e_read_result
+{
+	READ_EOF,
+	READ_EMPTY,
+	READ_OK
+}					t_read_result;
 
 typedef enum e_redir_type
 {

--- a/inc/main.h
+++ b/inc/main.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/03 12:50:38 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/04 12:26:20 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/08 16:22:31 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,5 +21,7 @@
 # include "tokenizer.h"
 # include <readline/history.h>
 # include <readline/readline.h>
+
+extern volatile sig_atomic_t	g_sig_sts;
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/03 12:50:11 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/08 16:57:52 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/08 17:00:17 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,15 @@ static t_read_result	_read_user_input(char **line)
 	return (READ_OK);
 }
 
+static void	_set_g_sig_sts(t_minish *minish)
+{
+	if (g_sig_sts)
+	{
+		minish->last_status = g_sig_sts;
+		g_sig_sts = 0;
+	}
+}
+
 /**
  * @brief I used bool type since it seems to be available.
  * @param program_name
@@ -48,6 +57,7 @@ static bool	prompt(char *program_name, t_minish *minish)
 		return (free_str(&line), false);
 	if (res == READ_EMPTY)
 		return (free_str(&line), true);
+	_set_g_sig_sts(minish);
 	tokens = tokenizer(line);
 	cmds = parser(tokens, minish);
 	if (!cmds)

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/03 12:50:11 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/05 18:56:10 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/08 16:57:52 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,17 @@ static void	destroy_minish(t_minish *minish)
 	rl_clear_history();
 }
 
+static t_read_result	_read_user_input(char **line)
+{
+	*line = readline("$ ");
+	if (!*line)
+		return (READ_EOF);
+	if ((*line)[0] == '\0')
+		return (READ_EMPTY);
+	add_history(*line);
+	return (READ_OK);
+}
+
 /**
  * @brief I used bool type since it seems to be available.
  * @param program_name
@@ -27,18 +38,16 @@ static void	destroy_minish(t_minish *minish)
  */
 static bool	prompt(char *program_name, t_minish *minish)
 {
-	char	*line;
-	char	**tokens;
-	t_cmd	**cmds;
+	char			*line;
+	char			**tokens;
+	t_cmd			**cmds;
+	t_read_result	res;
 
-	tokens = NULL;
-	cmds = NULL;
-	line = readline("$ ");
-	if (!line)
-		return (free_prompt(&tokens, &cmds, &line), false);
-	if (!line[0])
-		return (free(line), true);
-	add_history(line);
+	res = _read_user_input(&line);
+	if (res == READ_EOF)
+		return (free_str(&line), false);
+	if (res == READ_EMPTY)
+		return (free_str(&line), true);
 	tokens = tokenizer(line);
 	cmds = parser(tokens, minish);
 	if (!cmds)

--- a/src/minish_signal.c
+++ b/src/minish_signal.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 13:35:06 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/08 16:57:01 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/08 17:00:52 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ static void	ctrl_c(int signum)
 	rl_on_new_line();
 	rl_replace_line("", 0);
 	rl_redisplay();
-	g_sig_sts = signum + 2;
+	g_sig_sts = 128 + signum;
 }
 
 /**

--- a/src/minish_signal.c
+++ b/src/minish_signal.c
@@ -6,13 +6,13 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 13:35:06 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/08 16:24:32 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/08 16:57:01 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minish_signal.h"
 
-volatile sig_atomic_t g_sig_sts = 0;
+volatile sig_atomic_t	g_sig_sts = 0;
 
 /**
  * @brief Handler function when ctrl+c is pressed

--- a/src/minish_signal.c
+++ b/src/minish_signal.c
@@ -3,14 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   minish_signal.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 13:35:06 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/05 17:07:53 by dayano           ###   ########.fr       */
+/*   Updated: 2025/05/08 16:24:32 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minish_signal.h"
+
+volatile sig_atomic_t g_sig_sts = 0;
 
 /**
  * @brief Handler function when ctrl+c is pressed
@@ -24,6 +26,7 @@ static void	ctrl_c(int signum)
 	rl_on_new_line();
 	rl_replace_line("", 0);
 	rl_redisplay();
+	g_sig_sts = signum + 2;
 }
 
 /**


### PR DESCRIPTION
fixed #222

プロセス実行中の最終ステータスは取得できていましたが、プロンプト入力中にステータスが取得できていませんでした。

今回の対応でプロンプト入力中にシグナルを受信した際にもexitステータスを取得するようになりました。
また今回の変更に伴って、グローバル変数を追加しています。

### 確認方法
`./minish`でプロンプト入力中に`Ctrl+C`の後、`echo $?`で取得できているか確認できます。
