### PR TITLE
リダイレクト失敗時にbuiltin関数を実行しないように修正

### DIFF
--- a/inc/invoke_cmd/pipeline_helper.h
+++ b/inc/invoke_cmd/pipeline_helper.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 14:32:27 by dayano            #+#    #+#             */
-/*   Updated: 2025/05/04 19:18:38 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/09 11:33:04 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,6 @@
 # include <stdbool.h>
 
 // pipeline_helper.c
-void	redirect_stdout(t_cmd *cmd);
 bool	is_redirect(t_cmd *cmd);
 bool	is_head(t_cmd *cmd, t_cmd *cmd_head);
 bool	is_tail(t_cmd *cmd);

--- a/inc/invoke_cmd/redirect.h
+++ b/inc/invoke_cmd/redirect.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 15:20:03 by dayano            #+#    #+#             */
-/*   Updated: 2025/05/04 19:19:04 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/09 11:32:11 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,8 +15,8 @@
 
 # include "common.h"
 
-void	redirect(t_cmd *cmd);
-void	redirect_stdout(t_cmd *cmd);
-void	redirect_stdin(t_cmd *cmd);
+bool	redirect(t_cmd *cmd);
+bool	redirect_stdout(t_cmd *cmd);
+bool	redirect_stdin(t_cmd *cmd);
 
 #endif

--- a/src/invoke_cmd/invoke_command.c
+++ b/src/invoke_cmd/invoke_command.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   invoke_command.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dayano <dayano@student.42.fr>              +#+  +:+       +#+        */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/20 21:19:33 by dayano            #+#    #+#             */
-/*   Updated: 2025/05/05 17:39:02 by dayano           ###   ########.fr       */
+/*   Updated: 2025/05/09 11:43:50 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,12 +65,14 @@ int	execute_builtin(t_cmd *cmd, t_minish *minish)
 int	exec_unit_builtin(t_cmd *cmd, t_minish *minish)
 {
 	t_cmd	*builtin_cmd;
+	bool	redir_result;
 
+	redir_result = true;
 	builtin_cmd = cmd;
 	if (cmd && is_redirect(cmd))
 	{
-		redirect(cmd);
-		if (cmd->next)
+		redir_result = redirect(cmd);
+		if (redir_result && cmd->next)
 		{
 			cmd = cmd->next;
 			builtin_cmd = cmd;
@@ -79,7 +81,9 @@ int	exec_unit_builtin(t_cmd *cmd, t_minish *minish)
 			return (print_error(cmd->argv[0]), EXIT_FAILURE);
 	}
 	if (cmd->next && is_redirect(cmd->next))
-		redirect(cmd->next);
+		redir_result = redirect(cmd->next);
+	if (!redir_result)
+		return (EXIT_FAILURE);
 	return (execute_builtin(builtin_cmd, minish));
 }
 

--- a/src/invoke_cmd/redirect.c
+++ b/src/invoke_cmd/redirect.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 15:19:19 by dayano            #+#    #+#             */
-/*   Updated: 2025/05/09 11:38:36 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/09 14:23:25 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,7 +91,7 @@ bool	redirect_stdin(t_cmd *cmd)
 
 	path = cmd->argv[0];
 	if (cmd->type == REDIR_HEREDOC)
-		return (here_doc(path), false);
+		return (here_doc(path), true);
 	if (cmd->type != REDIR_IN)
 		return (true);
 	fd = open(path, O_RDONLY);


### PR DESCRIPTION
fixed #225 

### 対応内容
リダイレクト失敗時に結果の成否に関わらずビルトイン関数が実行される状態になっていましたので、
boolとして結果を返し、呼び出し元もそれにあわせて後続の処理を実行しないようにしました。

### 確認方法
- `./minishell`実行後、下記の点についてご確認いただけたらと思います。
  - `echo > <書き込み権限がないファイル>`で`minish: <file>: Permission denied`のみ表示されるか
  - `echo $?`で1が表示されるか

### 備考
- ビルトインの修正しか行っておりませんので、外部コマンドは別途対応が必要です。