### PR TITLE
Feature/256 fix syntax error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/04/03 12:55:20 by ttsubo            #+#    #+#              #
-#    Updated: 2025/05/16 11:17:59 by ttsubo           ###   ########.fr        #
+#    Updated: 2025/05/17 15:33:38 by ttsubo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -70,7 +70,7 @@ TOKENIZER_SRC	= 	tokenizer.c tokenizer_error.c read_token.c \
 PARSER_SRC		=	allocate_cmds.c  parser.c parser_utils.c  setup_cmds.c \
 					allocate_cmds_utils.c allocate_cmds_utils_2.c \
 					expand_env.c expand_tokens.c trim_quote_tokens.c \
-					split_by_quote.c join_expanded_parts.c
+					split_by_quote.c join_expanded_parts.c parser_validate.c
 BUILTIN_SRC		=	cd.c exit.c pwd.c echo.c env.c unset.c export.c \
 					env_utils.c env_utils_2.c env_utils_3.c builtin_utils.c \
 					export_exec.c export_exec_utils.c \

--- a/inc/parser/parser.h
+++ b/inc/parser/parser.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 14:14:59 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/06 14:26:28 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/17 14:19:47 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 # include "common.h"
 # include "env_utils.h"
 # include "expand_vars.h"
+# include "parser_validate.h"
 # include "libft.h"
 
 typedef enum e_quote

--- a/inc/parser/parser_validate.h
+++ b/inc/parser/parser_validate.h
@@ -1,0 +1,20 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser_validate.h                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/17 14:19:15 by ttsubo            #+#    #+#             */
+/*   Updated: 2025/05/17 15:26:46 by ttsubo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef PARSER_VALIDATE_H
+# define PARSER_VALIDATE_H
+
+# include "common.h"
+
+bool	parser_validate(t_cmd	***cmds_ptr, t_minish *minish);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/03 12:50:11 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/17 15:42:48 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/17 16:26:47 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,11 +71,9 @@ static bool	prompt(t_minish *minish)
 int	main(int argc, char **argv, char **envp)
 {
 	t_minish	*minish;
-	char		*program_name;
 	int			last_status;
 
 	(void)argc;
-	program_name = argv[0];
 	minish = initialize(envp);
 	minish_signal();
 	while (prompt(minish))

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/03 12:50:11 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/17 16:26:47 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/17 16:30:27 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,6 +74,7 @@ int	main(int argc, char **argv, char **envp)
 	int			last_status;
 
 	(void)argc;
+	(void)argv;
 	minish = initialize(envp);
 	minish_signal();
 	while (prompt(minish))

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/03 12:50:11 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/16 11:18:40 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/17 15:42:48 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,7 +45,7 @@ static void	_set_g_sig_sts(t_minish *minish)
  * @return true
  * @return false
  */
-static bool	prompt(char *program_name, t_minish *minish)
+static bool	prompt(t_minish *minish)
 {
 	char			*line;
 	char			**tokens;
@@ -61,11 +61,7 @@ static bool	prompt(char *program_name, t_minish *minish)
 	tokens = tokenizer(line);
 	cmds = parser(tokens, minish);
 	if (!cmds)
-	{
-		error_mes(program_name, ": syntax error");
-		free_prompt(&tokens, &cmds, &line);
-		return (true);
-	}
+		return (free_prompt(&tokens, &cmds, &line), true);
 	if (cmds[0]->argc > 0)
 		minish->last_status = invoke_commands(cmds[0], minish);
 	free_prompt(&tokens, &cmds, &line);
@@ -82,7 +78,7 @@ int	main(int argc, char **argv, char **envp)
 	program_name = argv[0];
 	minish = initialize(envp);
 	minish_signal();
-	while (prompt(program_name, minish))
+	while (prompt(minish))
 		;
 	last_status = minish->last_status;
 	destroy_minish(minish);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 14:14:32 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/15 15:48:56 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/17 15:39:05 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,6 +35,7 @@ t_cmd	**parser(char **tokens, t_minish *minish)
 	cmds = setup_cmds(cmds, formatted_tokens);
 	if (!cmds)
 		return (free_strs(&formatted_tokens), NULL);
+	parser_validate(&cmds, minish);
 	free_strs(&formatted_tokens);
 	return (cmds);
 }

--- a/src/parser/parser_validate.c
+++ b/src/parser/parser_validate.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/17 14:03:42 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/17 15:44:24 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/17 15:53:35 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,30 @@ static void	_error(char *arg)
 	ft_putstr_fd("minish: syntax error near unexpected token `", STDERR_FILENO);
 	ft_putstr_fd(arg, STDERR_FILENO);
 	ft_putendl_fd("'", STDERR_FILENO);
+}
+
+static bool _check_pipe(t_cmd *cmd, t_cmd ***cmds_ptr, t_minish *minish)
+{
+	if (cmd->type == REDIR_NONE && cmd->argc == 0)
+	{
+		_error("|");
+		minish->last_status = 2;
+		free_cmds(cmds_ptr);
+		return (false);
+	}
+	return (true);
+}
+
+static bool _check_redir(t_cmd *cmd, t_cmd ***cmds_ptr, t_minish *minish)
+{
+	if (cmd->type != REDIR_NONE && cmd->argc == 0)
+	{
+		_error("newline");
+		minish->last_status = 2;
+		free_cmds(cmds_ptr);
+		return (false);
+	}
+	return (true);
 }
 
 bool	parser_validate(t_cmd ***cmds_ptr, t_minish *minish)
@@ -30,13 +54,9 @@ bool	parser_validate(t_cmd ***cmds_ptr, t_minish *minish)
 	cmd = *cmds;
 	while (cmd)
 	{
-		if (cmd->type == REDIR_NONE && cmd->argc == 0)
-		{
-			_error("|");
-			minish->last_status = 2;
-			free_cmds(cmds_ptr);
+		if (!_check_pipe(cmd, cmds_ptr, minish)
+			|| !_check_redir(cmd, cmds_ptr, minish))
 			return (false);
-		}
 		cmd = cmd->next;
 	}
 	return (true);

--- a/src/parser/parser_validate.c
+++ b/src/parser/parser_validate.c
@@ -1,0 +1,43 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser_validate.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/17 14:03:42 by ttsubo            #+#    #+#             */
+/*   Updated: 2025/05/17 15:44:24 by ttsubo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "parser.h"
+
+static void	_error(char *arg)
+{
+	ft_putstr_fd("minish: syntax error near unexpected token `", STDERR_FILENO);
+	ft_putstr_fd(arg, STDERR_FILENO);
+	ft_putendl_fd("'", STDERR_FILENO);
+}
+
+bool	parser_validate(t_cmd ***cmds_ptr, t_minish *minish)
+{
+	t_cmd	*cmd;
+	t_cmd	**cmds;
+
+	if (!cmds_ptr || !*cmds_ptr)
+		return (true);
+	cmds = *cmds_ptr;
+	cmd = *cmds;
+	while (cmd)
+	{
+		if (cmd->type == REDIR_NONE && cmd->argc == 0)
+		{
+			_error("|");
+			minish->last_status = 2;
+			free_cmds(cmds_ptr);
+			return (false);
+		}
+		cmd = cmd->next;
+	}
+	return (true);
+}

--- a/src/parser/parser_validate.c
+++ b/src/parser/parser_validate.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/17 14:03:42 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/17 15:53:35 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/17 16:02:37 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ static void	_error(char *arg)
 	ft_putendl_fd("'", STDERR_FILENO);
 }
 
-static bool _check_pipe(t_cmd *cmd, t_cmd ***cmds_ptr, t_minish *minish)
+static bool	_check_pipe(t_cmd *cmd, t_cmd ***cmds_ptr, t_minish *minish)
 {
 	if (cmd->type == REDIR_NONE && cmd->argc == 0)
 	{
@@ -31,7 +31,7 @@ static bool _check_pipe(t_cmd *cmd, t_cmd ***cmds_ptr, t_minish *minish)
 	return (true);
 }
 
-static bool _check_redir(t_cmd *cmd, t_cmd ***cmds_ptr, t_minish *minish)
+static bool	_check_redir(t_cmd *cmd, t_cmd ***cmds_ptr, t_minish *minish)
 {
 	if (cmd->type != REDIR_NONE && cmd->argc == 0)
 	{


### PR DESCRIPTION
fixed #256 
パイプ、リダイレクトが正しく実行できないときのチェックを追加しました。
正しい形式ではないとエラーメッセージとstatusが2になります。

### 確認方法
- minishell起動後`|`や`<<`など単体入力や`| echo hello`など不正な入力を確認ください。
  - `minish: syntax error near unexpected token `|'`のように表示されます。
