### PR TITLE
リダイレクトエラー時にminishのlast-statusにセットするように修正

### DIFF
--- a/inc/tokenizer/tokenizer.h
+++ b/inc/tokenizer/tokenizer.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 12:36:01 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/17 15:13:49 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/17 16:18:06 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 # define TOKENIZER_H
 
 # include "libft.h"
+# include "common.h"
 # include <stdio.h>
 
 # define ERR_UNEXPECTED_STR "unexpected error occureed.\n"
@@ -59,7 +60,7 @@ char		*read_token(t_tokenizer *tkn);
 void		show_tokenizer_error(t_tokenizer_errors err_code);
 size_t		get_token_capa(char *str);
 int			is_quote_closed(char *str);
-int			is_redirect_validate(char *str);
-char		**tokenizer(char *str);
+int			is_redirect_validate(char *str, t_minish *minish);
+char		**tokenizer(char *str, t_minish *minish);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/03 12:50:11 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/05/16 11:18:40 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/17 16:21:48 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,7 +58,7 @@ static bool	prompt(char *program_name, t_minish *minish)
 	if (res == READ_EMPTY)
 		return (free_str(&line), true);
 	_set_g_sig_sts(minish);
-	tokens = tokenizer(line);
+	tokens = tokenizer(line, minish);
 	cmds = parser(tokens, minish);
 	if (!cmds)
 	{

--- a/src/tokenizer/is_redirect_validate.c
+++ b/src/tokenizer/is_redirect_validate.c
@@ -6,11 +6,17 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 13:59:15 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/27 15:03:26 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/17 16:19:18 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "tokenizer.h"
+
+static void	_show_err_and_set_sts(t_tokenizer_errors err_code, t_minish *minish)
+{
+	show_tokenizer_error(err_code);
+	minish->last_status = 2;
+}
 
 /**
  * @brief Checks if the redirect symbol is a valid value.
@@ -18,24 +24,14 @@
  * @return int
  * @note For now, this function only checks for consecutive redirect symbols.
  */
-int	is_redirect_validate(char *str)
+int	is_redirect_validate(char *str, t_minish *minish)
 {
 	while (*str)
 	{
-		if (!ft_strncmp(str, ">>>", 3))
-			return (show_tokenizer_error(ERR_UNEXPECTED_TOKEN_R1), 0);
-		else if (!ft_strncmp(str, "<<<", 3))
-			return (show_tokenizer_error(ERR_UNEXPECTED_TOKEN_L1), 0);
-		if (*str == '>')
-		{
-			if (*(str + 1) == '<')
-				return (show_tokenizer_error(ERR_UNEXPECTED_TOKEN_L1), 0);
-		}
-		if (*str == '<')
-		{
-			if (*(str + 1) == '>')
-				return (show_tokenizer_error(ERR_UNEXPECTED_TOKEN_R1), 0);
-		}
+		if (!ft_strncmp(str, ">>>", 3) || (*str == '<' && *(str + 1) == '>'))
+			return (_show_err_and_set_sts(ERR_UNEXPECTED_TOKEN_R1, minish), 0);
+		if (!ft_strncmp(str, "<<<", 3) || (*str == '>' && *(str + 1) == '<'))
+			return (_show_err_and_set_sts(ERR_UNEXPECTED_TOKEN_L1, minish), 0);
 		str++;
 	}
 	return (1);

--- a/src/tokenizer/tokenizer.c
+++ b/src/tokenizer/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 12:35:38 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/04/29 14:58:23 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/05/17 16:10:10 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,14 +24,14 @@ void	skip_spaces(t_tokenizer *tkn)
  * @param str
  * @return char**
  */
-char	**tokenizer(char *str)
+char	**tokenizer(char *str, t_minish *minish)
 {
 	int			token_i;
 	char		**tokens;
 	t_tokenizer	tkn;
 
 	tkn = (t_tokenizer){.input = str, .pos = 0, .in_squote = 0, .in_dquote = 0};
-	if (!is_redirect_validate(str))
+	if (!is_redirect_validate(str, minish))
 		return (NULL);
 	tokens = ft_calloc(get_token_capa(str) + 1, sizeof(char *));
 	if (!tokens)


### PR DESCRIPTION
fixed #255 

不正なリダイレクトエラー時にステータスコードを返せていなかったので返すように設定しました。

### 確認方法
minishellで`<<<`のような不正なリダイレクトエラーを入力後、`echo $?`でExit Statusに2が入っているかご確認ください。

### 備考
上記確認でsyntax Errorというメッセージが出ますが、#256のマージで消える予定ですので無視してください。