### PR TITLE
fix redirect

### DIFF
--- a/src/invoke_cmd/invoke_command.c
+++ b/src/invoke_cmd/invoke_command.c
@@ -66,22 +66,18 @@ int	execute_builtin(t_cmd *cmd, t_minish *minish)
 int	exec_unit_builtin(t_cmd *cmd, t_minish *minish)
 {
 	t_cmd	*builtin_cmd;
+	t_cmd	*redir_cmd;
 	bool	redir_result;
 
-	redir_result = true;
 	builtin_cmd = cmd;
-	if (cmd && cmd->next && is_redirect(cmd->next))
+	redir_cmd = cmd->next;
+	while (redir_cmd && is_redirect(redir_cmd))
 	{
-		redir_result = redirect(cmd->next);
-		if (redir_result && cmd->next)
-			cmd = cmd->next;
-		else
-			return (print_error(cmd->argv[0]), EXIT_FAILURE);
+		redir_result = redirect(redir_cmd);
+		if (!redir_result)
+			return (print_error(builtin_cmd->argv[0]), EXIT_FAILURE);
+		redir_cmd = redir_cmd->next;
 	}
-	if (cmd && cmd->next && is_redirect(cmd->next))
-		redir_result = redirect(cmd->next);
-	if (!redir_result)
-		return (EXIT_FAILURE);
 	return (execute_builtin(builtin_cmd, minish));
 }
 


### PR DESCRIPTION
fix #268 

リダイレクトは３つ以上受け付けられるように修正しました。
./minishellで確認していただけるとありがたいです。
```
$ echo hello < Makefile > out > out2 > out3
$ echo hello < Makefile < README.md > out > out2 > out3
$ echo bye < Makefile < README.md > out > out2 > out3
```
ただ、以下のようにリダイレクト後やリダイレクト間にテキストがあった場合は、処理できないです。
```
$ echo hello < Makefile > out > out2 > out3 bye
$ echo hello < Makefile < README.md hi > out > out2 > out3 hey
```
